### PR TITLE
Fix: Add `chonkie.utils` module to package list in `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,7 @@ packages = [
     "chonkie.types",
     "chonkie.embeddings",
     "chonkie.cloud",
+    "chonkie.utils"
 ]
 
 [tool.ruff]


### PR DESCRIPTION
This pull request includes a small change to the `pyproject.toml` file. The change adds the `chonkie.utils` package to the list of packages.