### PR TITLE
Fix: Export `CodeChunker` properly to the main `chonkie.__init__` + Bump up version to `v1.0.5`

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Tired of making your gazillionth chunker? Sick of the overhead of large librarie
 **✨ Easy to use**: Install, Import, CHONK </br>
 **⚡ Fast**: CHONK at the speed of light! zooooom </br>
 **🪶 Light-weight**: No bloat, just CHONK </br>
-**🌏 Wide support**: CHONK with your favorite tokenizer, embedding model and APIs! </br>
+**🌏 Wide support**: CHONKie [integrates](#integrations) with your favorite tokenizer, embedding model and APIs! </br>
 **💬 ️Multilingual**: Out-of-the-box support for 5+ language CHONKS (more coming 🔜) </br>
 **☁️ Cloud-Ready**: CHONK locally or in the [Chonkie Cloud](https://cloud.chonkie.ai) </br>
 **🦛 Cute CHONK mascot**: psst it's a pygmy hippo btw </br>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "chonkie"
-version = "1.0.4"
+version = "1.0.5"
 description = "🦛 CHONK your texts with Chonkie ✨ - The no-nonsense chunking library"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/chonkie/__init__.py
+++ b/src/chonkie/__init__.py
@@ -2,13 +2,13 @@
 
 from .chunker import (
     BaseChunker,
+    CodeChunker,
     LateChunker,
     RecursiveChunker,
     SDPMChunker,
     SemanticChunker,
     SentenceChunker,
     TokenChunker,
-    CodeChunker
 )
 from .embeddings import (
     AutoEmbeddings,
@@ -44,7 +44,7 @@ from .utils import (
 )
 
 # This hippo grows with every release 🦛✨~
-__version__ = "1.0.4"
+__version__ = "1.0.5"
 __name__ = "chonkie"
 __author__ = "🦛 Chonkie Inc"
 

--- a/src/chonkie/chunker/__init__.py
+++ b/src/chonkie/chunker/__init__.py
@@ -1,13 +1,13 @@
 """Module for chunkers."""
 
 from .base import BaseChunker
+from .code import CodeChunker
 from .late import LateChunker
 from .recursive import RecursiveChunker
 from .sdpm import SDPMChunker
 from .semantic import SemanticChunker
 from .sentence import SentenceChunker
 from .token import TokenChunker
-from .code import CodeChunker
 
 __all__ = [
     "BaseChunker",

--- a/tests/chunkers/test_code_chunker.py
+++ b/tests/chunkers/test_code_chunker.py
@@ -1,7 +1,7 @@
 """Test the CodeChunker class."""
 import pytest
 
-from chonkie.chunker.code import CodeChunker
+from chonkie import CodeChunker
 from chonkie.types.code import CodeChunk
 
 


### PR DESCRIPTION
This pull request introduces a new `CodeChunker` class to the `chonkie` library and updates the version to `1.0.5`. The changes primarily focus on adding the new chunker and ensuring it is properly integrated into the module's exports.

### Version Update:
* Updated the version from `1.0.4` to `1.0.5` in `pyproject.toml` and `src/chonkie/__init__.py`. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R7) [[2]](diffhunk://#diff-44a557df57b150a7b71a0b691e66e501f00f8983cc9c66dee9309aaf738bd408L46-R47)

### Integration of `CodeChunker`:
* Added `CodeChunker` to the import statements in `src/chonkie/__init__.py` and `src/chonkie/chunker/__init__.py`. [[1]](diffhunk://#diff-44a557df57b150a7b71a0b691e66e501f00f8983cc9c66dee9309aaf738bd408R5) [[2]](diffhunk://#diff-b9f7a0e97cb51825efbeeb27c7cfa1aafcaba2213c98ff81d052b1fc909940a1R4)
* Included `CodeChunker` in the `__all__` exports of `src/chonkie/__init__.py` and `src/chonkie/chunker/__init__.py` to make it publicly accessible. [[1]](diffhunk://#diff-44a557df57b150a7b71a0b691e66e501f00f8983cc9c66dee9309aaf738bd408R89) [[2]](diffhunk://#diff-b9f7a0e97cb51825efbeeb27c7cfa1aafcaba2213c98ff81d052b1fc909940a1R20)