### PR TITLE
Feat: update workflow

### DIFF
--- a/.github/workflows/python-test-pr.yml
+++ b/.github/workflows/python-test-pr.yml
@@ -28,7 +28,7 @@ jobs:
         run: uv sync --all-extras --dev
 
       - name: Lint with Ruff
-        run: ruff check --fix
+        run: ruff check
         continue-on-error: true
 
       - name: Cache Hugging Face models


### PR DESCRIPTION
the current workflow does not not capture all ruff errors because all of fixable ones are captured and fixed on its end and are not being pushed back to the original pr.

this pull request mainly comes to fix this issue 