### PR TITLE
Tutorial: Update the readability of the tutorial with better markdown 

### DIFF
--- a/cookbook/tutorials/Chonkie_SlumberChunker_w_OpenRouter_models.ipynb
+++ b/cookbook/tutorials/Chonkie_SlumberChunker_w_OpenRouter_models.ipynb
@@ -94,76 +94,24 @@
       },
       "outputs": [],
       "source": [
+        "# Let's initialize all the components we'll need for this tutorial!\n",
+        "\n",
         "# Initializing a rich console\n",
-        "console = Console(width=88) # width set to 88, because it looks good 😌"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 4,
-      "metadata": {
-        "id": "byuxYv-_wAxq"
-      },
-      "outputs": [],
-      "source": [
+        "console = Console(width=88) # width set to 88, because it looks good 😌\n",
+        "\n",
         "# initializing the visualizer\n",
-        "viz = Visualizer()"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 5,
-      "metadata": {
-        "id": "HwVM0bm9ymma"
-      },
-      "outputs": [],
-      "source": [
+        "viz = Visualizer()\n",
+        "\n",
         "# setting the OPENROUTER_API_KEY with the help of colab's feature~\n",
-        "OPENROUTER_API_KEY = userdata.get(\"OPENROUTER_API_KEY\")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 10,
-      "metadata": {
-        "id": "gBrTJAtIwiI3"
-      },
-      "outputs": [],
-      "source": [
+        "OPENROUTER_API_KEY = userdata.get(\"OPENROUTER_API_KEY\")\n",
+        "\n",
         "# Let's set-up our genie to work with OpenRouter\n",
         "genie = OpenAIGenie(\n",
         "    model = \"cohere/command-r-plus-08-2024\",\n",
         "    base_url = \"https://openrouter.ai/api/v1\",\n",
         "    api_key=OPENROUTER_API_KEY\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 176,
-          "referenced_widgets": [
-            "c469be5c13544602b2709f86f2e95685",
-            "da9734224b544b54bb4701e249ee37a0",
-            "c46833627e524aecb0c1cc19e9482c9b",
-            "212ea79718e643c286dc3e5b27b3850b",
-            "095cca01d4b6413ba67e80595dd815da",
-            "0827e691a07d4cf6bb6e0ff325a54dc5",
-            "1e3a111f914e43839d14dd44bd26f844",
-            "fd1657c58ead4fc68f29960f279983a3",
-            "044a16e3e8ab49c284e67f945c652e07",
-            "9d1d0ca0c38c4cbe9ec037fd5b8a7606",
-            "e39461bd75764962acee1b0df817f086"
-          ]
-        },
-        "id": "YTDxAfffy8eF",
-        "outputId": "0a39017f-6ecc-4538-e7b1-1289dea46675"
-      },
-      "outputs": [],
-      "source": [
+        ")\n",
+        "\n",
         "# Now, we can use the above genie with the SlumberChunker\n",
         "chunker = SlumberChunker(\n",
         "    genie=genie,\n",
@@ -173,6 +121,13 @@
         "    min_characters_per_chunk=24,\n",
         "    return_type=\"chunks\"\n",
         ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Awesome~ We now have everything set-up to use the SlumberChunker with OpenRouter!\n"
       ]
     },
     {

--- a/cookbook/tutorials/Chonkie_SlumberChunker_w_OpenRouter_models.ipynb
+++ b/cookbook/tutorials/Chonkie_SlumberChunker_w_OpenRouter_models.ipynb
@@ -181,7 +181,7 @@
         "id": "oqqfaCL3VbHp"
       },
       "source": [
-        "## Case 1: Article-esque Text with clear sectional demarcations!"
+        "## Now, let's CHONK some documents!"
       ]
     },
     {


### PR DESCRIPTION
This pull request updates the tutorial notebook `Chonkie_SlumberChunker_w_OpenRouter_models.ipynb` to improve readability and streamline the setup process. The changes include consolidating initialization steps, adding a new markdown explanation, and renaming a section header for clarity.

### Improvements to tutorial structure:

* Consolidated initialization steps for components like `Console`, `Visualizer`, and `OpenAIGenie` into a single code cell to improve readability and reduce redundancy.

### Enhancements to user guidance:

* Added a new markdown cell to confirm that the setup is complete and ready for use with SlumberChunker and OpenRouter.
* Renamed a markdown section header from "Case 1: Article-esque Text with clear sectional demarcations!" to "Now, let's CHONK some documents!" for a more engaging and user-friendly tone.