### PR TITLE
Fix: Linting errors + Add `cloud.SDPMChunker` + `cloud.LateChunker` 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,9 +55,15 @@ Documentation = "https://docs.chonkie.ai"
 
 
 [project.optional-dependencies]
+# Optional dependencies for the utils
 hub = ["huggingface-hub>=0.24.0", "jsonschema>=4.23.0"]
 viz = ["rich>=13.0.0"]
+
+# Optional dependencies for the chunkers
 code = ["tree-sitter>=0.20.0", "tree-sitter-language-pack>=0.7.0", "magika>=0.6.0, <0.7.0"]
+neural = ["transformers>=4.0.0", "torch>=2.0.0, <3.0"]
+
+# Optional dependencies for the embeddings
 model2vec = ["model2vec>=0.3.0", "numpy>=2.0.0, <3.0"]
 st = ["sentence-transformers>=3.0.0", "numpy>=2.0.0, <3.0", "accelerate>=1.6.0"]
 openai = ["tiktoken>=0.5.0", "openai>=1.0.0", "numpy>=2.0.0, <3.0", "pydantic>=2.0.0"]
@@ -65,12 +71,17 @@ voyageai = ["voyageai>=0.3.2", "numpy>=2.0.0, <3.0"]
 cohere = ["cohere>=5.13.0", "numpy>=2.0.0, <3.0"]
 jina = ["numpy>=2.0.0, <3.0"]
 semantic = ["model2vec>=0.3.0", "numpy>=2.0.0, <3.0"]
-neural = ["transformers>=4.0.0", "torch>=2.0.0, <3.0"]
 gemini = ["pydantic>=2.0.0", "google-genai>=1.0.0"]
-genie = ["pydantic>=2.0.0", "google-genai>=1.0.0"]
+
+# optional dependencies for the friends
 chroma = ["chromadb>=1.0.0"]
 qdrant = ["qdrant-client>=1.0.0"]
 tpuf = ["turbopuffer[fast]>=0.2.0"]
+
+# Optional dependencies for the genie
+genie = ["pydantic>=2.0.0", "google-genai>=1.0.0"]
+
+# All dependencies
 all = [
     "rich>=13.0.0",
     "tree-sitter>=0.20.0",

--- a/src/chonkie/cloud/__init__.py
+++ b/src/chonkie/cloud/__init__.py
@@ -2,7 +2,9 @@
 
 from .chunker import (
     CloudChunker,
+    LateChunker,
     RecursiveChunker,
+    SDPMChunker,
     SemanticChunker,
     SentenceChunker,
     TokenChunker,
@@ -14,4 +16,6 @@ __all__ = [
     "RecursiveChunker",
     "SemanticChunker",
     "SentenceChunker",
+    "LateChunker",
+    "SDPMChunker",
 ]

--- a/src/chonkie/cloud/chunker/__init__.py
+++ b/src/chonkie/cloud/chunker/__init__.py
@@ -1,7 +1,9 @@
 """Module for Chonkie Cloud Chunkers."""
 
 from .base import CloudChunker
+from .late import LateChunker
 from .recursive import RecursiveChunker
+from .sdpm import SDPMChunker
 from .semantic import SemanticChunker
 from .sentence import SentenceChunker
 from .token import TokenChunker
@@ -12,4 +14,6 @@ __all__ = [
     "SemanticChunker",
     "TokenChunker",
     "SentenceChunker",
+    "LateChunker",
+    "SDPMChunker",
 ]

--- a/src/chonkie/cloud/chunker/late.py
+++ b/src/chonkie/cloud/chunker/late.py
@@ -1,0 +1,154 @@
+"""Late Chunking for Chonkie API."""
+
+from typing import Dict, List, Optional, Union, cast
+
+import requests
+
+from chonkie.types import RecursiveRules
+
+from .recursive import RecursiveChunker
+
+
+class LateChunker(RecursiveChunker):
+    """Late Chunking for Chonkie API.
+
+    This class sends requests to the Chonkie API's late chunking endpoint.
+    """
+
+    def __init__(
+        self,
+        embedding_model: str = "sentence-transformers/all-MiniLM-L6-v2",
+        chunk_size: int = 512,
+        min_characters_per_chunk: int = 24,  # Default from local LateChunker
+        rules: RecursiveRules = RecursiveRules(),
+        api_key: Optional[str] = None,
+    ) -> None:
+        """Initialize the LateChunker for the Chonkie Cloud API.
+
+        Args:
+            embedding_model: The name or identifier of the embedding model to be used by the API.
+            chunk_size: The target maximum size of each chunk (in tokens, as defined by the embedding model's tokenizer).
+            min_characters_per_chunk: The minimum number of characters a chunk should have.
+            rules: The recursive splitting rules to apply before late interaction.
+            api_key: The Chonkie API key. If None, it's read from the CHONKIE_API_KEY environment variable.
+
+        """
+        self.embedding_model = embedding_model
+        # The API key, base URL, version, and API health check are handled by the superclass.
+        # Parameters like chunk_size, min_characters_per_chunk, and rules are also set by super().__init__.
+        super().__init__(
+            api_key=api_key,
+            chunk_size=chunk_size,
+            min_characters_per_chunk=min_characters_per_chunk,
+            rules=rules,
+            # tokenizer_or_token_counter is required by RecursiveChunker's __init__,
+            # but its specific value is less critical here as the late chunking endpoint
+            # will primarily use the embedding_model. A generic default is provided.
+            tokenizer_or_token_counter="gpt2",
+            return_type="chunks",  # Assuming the API returns structured chunk data
+        )
+
+    def chunk(self, text: Union[str, List[str]]) -> List[Dict]:
+        """Chunk the text into a list of late-interaction chunks via the Chonkie API.
+
+        Args:
+            text: The text or list of texts to chunk.
+
+        Returns:
+            A list of dictionaries, where each dictionary represents a chunk
+            and is expected to contain text, start/end indices, token count, and embedding.
+
+        Raises:
+            ValueError: If the API returns an error or an invalid response.
+
+        """
+        # Make the payload
+        payload = {
+            "text": text,
+            "embedding_model": self.embedding_model,
+            "chunk_size": self.chunk_size,
+            "min_characters_per_chunk": self.min_characters_per_chunk,
+            "rules": self.rules.to_dict(),
+            # "return_type": self.return_type, # Implicitly "late_chunks" by endpoint
+        }
+
+        # Make the request to the Chonkie API's late chunking endpoint
+        # Assuming the endpoint is /chunk/late, similar to /chunk/recursive
+        response = requests.post(
+            f"{self.BASE_URL}/{self.VERSION}/chunk/late",  # Assumed new endpoint
+            json=payload,
+            headers={"Authorization": f"Bearer {self.api_key}"},
+        )
+
+        # Try to parse the response
+        try:
+            response.raise_for_status()  # Raise an exception for HTTP errors (4xx or 5xx)
+            result: List[Dict] = cast(List[Dict], response.json())
+        except requests.exceptions.HTTPError as http_error:
+            # Attempt to get more detailed error from API response if possible
+            error_detail = ""
+            try:
+                error_detail = response.json().get("detail", "")
+            except requests.exceptions.JSONDecodeError:
+                error_detail = response.text
+            raise ValueError(
+                f"Oh no! Chonkie API returned an error for late chunking: {http_error}. "
+                f"Details: {error_detail}"
+                + "If the issue persists, please contact support at support@chonkie.ai."
+            ) from http_error
+        except requests.exceptions.JSONDecodeError as error:
+            raise ValueError(
+                "Oh no! The Chonkie API returned an invalid JSON response for late chunking."
+                + "Please try again in a short while."
+                + "If the issue persists, please contact support at support@chonkie.ai."
+            ) from error
+        except Exception as error: # Catch any other unexpected errors
+            raise ValueError(
+                "An unexpected error occurred while processing the response from Chonkie API for late chunking."
+                + "Please try again in a short while."
+                + "If the issue persists, please contact support at support@chonkie.ai."
+            ) from error
+            
+        return result
+
+    @classmethod
+    def from_recipe( # type: ignore
+        cls,
+        name: Optional[str] = "default",
+        lang: Optional[str] = "en",
+        path: Optional[str] = None,
+        embedding_model: str = "sentence-transformers/all-MiniLM-L6-v2",
+        chunk_size: int = 512,
+        min_characters_per_chunk: int = 24,
+        api_key: Optional[str] = None,
+    ) -> "LateChunker":
+        """Create a LateChunker from a recipe.
+
+        Args:
+            name: The name of the recipe to use.
+            lang: The language that the recipe should support.
+            path: The path to the recipe to use.
+            embedding_model: The name or identifier of the embedding model to be used by the API.
+            chunk_size: The chunk size to use.
+            min_characters_per_chunk: The minimum number of characters per chunk.
+            api_key: The Chonkie API key.
+
+        Returns:
+            LateChunker: The created LateChunker.
+
+        Raises:
+            ValueError: If the recipe is invalid or if the recipe is not found.
+            
+        """
+        rules = RecursiveRules.from_recipe(name=name, lang=lang, path=path)
+        return cls(
+            embedding_model=embedding_model,
+            chunk_size=chunk_size,
+            rules=rules,
+            min_characters_per_chunk=min_characters_per_chunk,
+            api_key=api_key,
+        )
+
+    def __call__(self, text: Union[str, List[str]]) -> List[Dict]:
+        """Call the LateChunker to chunk text."""
+        return self.chunk(text)

--- a/src/chonkie/cloud/chunker/sdpm.py
+++ b/src/chonkie/cloud/chunker/sdpm.py
@@ -1,0 +1,203 @@
+"""Semantic Double-Pass Merging for Chonkie API."""
+
+import os
+from typing import Any, Dict, List, Literal, Optional, Union, cast
+
+import requests
+
+from .base import CloudChunker
+
+
+class SDPMChunker(CloudChunker):
+    """Semantic Double-Pass Merging for Chonkie API.
+    
+    This chunker uses the Semantic Double-Pass Merging algorithm to chunk text.
+
+    Args:
+        embedding_model: The embedding model to use.
+        mode: The mode to use.
+        threshold: The threshold to use.
+        chunk_size: The chunk size to use.
+        similarity_window: The similarity window to use.
+        min_sentences: The minimum number of sentences to use.
+        min_chunk_size: The minimum chunk size to use.
+        min_characters_per_sentence: The minimum number of characters per sentence to use.
+        threshold_step: The threshold step to use.
+        delim: The delimiters to use.
+        include_delim: Whether to include delimiters in chunks.
+        skip_window: The skip window to use.
+        return_type: The return type to use.
+        api_key: The API key to use.
+        **kwargs: Additional keyword arguments.
+        
+    """
+
+    def __init__(self,
+                 embedding_model: str = "minishlab/potion-base-8M",
+                 mode: str = "window",
+                 threshold: Union[str, float, int] = "auto",
+                 chunk_size: int = 512,
+                 similarity_window: int = 1,
+                 min_sentences: int = 1,
+                 min_chunk_size: int = 2,
+                 min_characters_per_sentence: int = 12,
+                 threshold_step: float = 0.01,
+                 delim: Union[str, List[str]] = [". ", "! ", "? ", "\n"],
+                 include_delim: Optional[Literal["prev", "next"]] = "prev",
+                 skip_window: int = 1,
+                 return_type: Literal["chunks", "texts"] = "chunks",
+                 api_key: Optional[str] = None, 
+                 **kwargs: Dict[str, Any]) -> None:
+        """Initialize the SemanticDoublePassMerger.
+        
+        Args:
+            embedding_model: The embedding model to use.
+            mode: The mode to use.
+            threshold: The threshold to use.
+            chunk_size: The chunk size to use.
+            similarity_window: The similarity window to use.
+            min_sentences: The minimum number of sentences to use.
+            min_chunk_size: The minimum chunk size to use.
+            min_characters_per_sentence: The minimum number of characters per sentence to use.
+            threshold_step: The threshold step to use.
+            delim: The delimiters to use.
+            include_delim: Whether to include delimiters in chunks.
+            skip_window: The skip window to use.
+            return_type: The return type to use.
+            api_key: The API key to use.
+            **kwargs: Additional keyword arguments.
+
+        """
+        super().__init__()
+
+        # Get the API key
+        self.api_key = api_key or os.getenv("CHONKIE_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "No API key provided. Please set the CHONKIE_API_KEY environment variable"
+                + "or pass an API key to the SemanticChunker constructor."
+            )
+
+        # Validate all the parameters
+        # Check if the chunk size is valid
+        if chunk_size <= 0:
+            raise ValueError("Chunk size must be greater than 0.")
+
+        # Check if the threshold is valid
+        if isinstance(threshold, str) and threshold != "auto":
+            raise ValueError("Threshold must be either 'auto' or a number between 0 and 1.")
+
+        # Check if the similarity window is valid
+        if similarity_window <= 0:
+            raise ValueError("Similarity window must be greater than 0.")
+        
+        # Check if the minimum sentences is valid
+        if min_sentences <= 0:
+            raise ValueError("Minimum sentences must be greater than 0.")
+        
+        # Check if the minimum chunk size is valid
+        if min_chunk_size <= 0:
+            raise ValueError("Minimum chunk size must be greater than 0.")
+        
+        # Check if the minimum characters per sentence is valid
+        if min_characters_per_sentence <= 0:
+            raise ValueError("Minimum characters per sentence must be greater than 0.")
+        
+        # Check if the threshold step is valid
+        if threshold_step <= 0:
+            raise ValueError("Threshold step must be greater than 0.")
+        
+        # Check if the delimiters are valid
+        if not isinstance(delim, list):
+            raise ValueError("Delimiters must be a list.")
+        
+        # Check if the include_delim is valid
+        if include_delim not in ["prev", "next"]:
+            raise ValueError("Include delim must be either 'prev' or 'next'.")
+
+        # Check if the skip_window is valid
+        if skip_window <= 0:
+            raise ValueError("Skip window must be greater than 0.")
+        
+        # Check if the return_type is valid
+        if return_type not in ["chunks", "texts"]:
+            raise ValueError("Return type must be either 'chunks' or 'texts'.")
+
+        # Check if the embedding model is a string
+        if not isinstance(embedding_model, str):
+            raise ValueError("Embedding model must be a string.")
+        
+        # Initialize the chunker
+        self.embedding_model = embedding_model
+        self.mode = mode
+        self.threshold = threshold
+        self.chunk_size = chunk_size
+        self.similarity_window = similarity_window
+        self.min_sentences = min_sentences
+        self.min_chunk_size = min_chunk_size
+        self.min_characters_per_sentence = min_characters_per_sentence
+        self.threshold_step = threshold_step
+        self.delim = delim
+        self.include_delim = include_delim
+        self.skip_window = skip_window
+        self.return_type = return_type
+
+
+    def chunk(self, text: Union[str, List[str]]) -> List[Dict]:
+        """Chunk the text into a list of chunks.
+        
+        Args:
+            text: The text to chunk.
+            
+        Returns:
+            A list of chunks.
+
+        """
+        # Make the payload
+        payload = {
+            "text": text,
+            "embedding_model": self.embedding_model,
+            "mode": self.mode,
+            "threshold": self.threshold,
+            "chunk_size": self.chunk_size,
+            "similarity_window": self.similarity_window,
+            "min_sentences": self.min_sentences,
+            "min_chunk_size": self.min_chunk_size,
+            "min_characters_per_sentence": self.min_characters_per_sentence,
+            "threshold_step": self.threshold_step,
+            "delim": self.delim,
+            "include_delim": self.include_delim,
+            "skip_window": self.skip_window,
+            "return_type": self.return_type,
+        }
+
+        # Make the request to the Chonkie API
+        response = requests.post(
+            f"{self.BASE_URL}/{self.VERSION}/chunk/semantic",
+            json=payload,
+            headers={"Authorization": f"Bearer {self.api_key}"},
+        )
+
+        # Try to parse the response
+        try:
+            result: List[Dict] = cast(List[Dict], response.json())
+        except Exception as error:
+            raise ValueError(
+                "Oh no! The Chonkie API returned an invalid response."
+                + "Please try again in a short while."
+                + "If the issue persists, please contact support at support@chonkie.ai."
+            ) from error
+
+        return result
+
+    def __call__(self, text: Union[str, List[str]]) -> List[Dict]:
+        """Call the chunker.
+        
+        Args:
+            text: The text to chunk.
+            
+        Returns:
+            A list of chunks.
+
+        """
+        return self.chunk(text)

--- a/src/chonkie/cloud/chunker/semantic.py
+++ b/src/chonkie/cloud/chunker/semantic.py
@@ -31,6 +31,8 @@ class SemanticChunker(CloudChunker):
         api_key: Optional[str] = None,
     ) -> None:
         """Initialize the Chonkie Cloud Semantic Chunker."""
+        super().__init__()
+        
         # Get the API key
         self.api_key = api_key or os.getenv("CHONKIE_API_KEY")
         if not self.api_key:

--- a/src/chonkie/friends/handshakes/turbopuffer.py
+++ b/src/chonkie/friends/handshakes/turbopuffer.py
@@ -1,8 +1,8 @@
 """Turbopuffer Handshake to export Chonkie's Chunks into a Turbopuffer database."""
-import os
 import importlib.util as importutil
+import os
 import warnings
-from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Sequence, Union
+from typing import TYPE_CHECKING, Any, Literal, Optional, Sequence, Union
 from uuid import NAMESPACE_OID, uuid5
 
 from chonkie.embeddings import AutoEmbeddings, BaseEmbeddings

--- a/src/chonkie/types/document.py
+++ b/src/chonkie/types/document.py
@@ -3,7 +3,7 @@
 Documents allows chonkie to work together with other libraries that have their own 
 document types — ensuring that the transition between libraries is as seamless as possible!
 
-Additionally, documents are used to link together mulitple sources of metadata that can be 
+Additionally, documents are used to link together multiple sources of metadata that can be 
 leveraged in downstream use-cases. One example of this would be in-line images, which are
 stored as base64 encoded strings in the `metadata` field.
 

--- a/src/chonkie/types/document.py
+++ b/src/chonkie/types/document.py
@@ -1,7 +1,20 @@
-"""Document type for Chonkie."""
+"""Document type for Chonkie.
+
+Documents allows chonkie to work together with other libraries that have their own 
+document types — ensuring that the transition between libraries is as seamless as possible!
+
+Additionally, documents are used to link together mulitple sources of metadata that can be 
+leveraged in downstream use-cases. One example of this would be in-line images, which are
+stored as base64 encoded strings in the `metadata` field.
+
+Lastly, documents are used by the chunkers to understand that they are working with chunks
+of a document and not an assortment of text when dealing with hybrid/dual-mode chunking. 
+
+This class is designed to be extended and might go through significant changes in the future.
+"""
 
 from dataclasses import dataclass, field
-from typing import List, Optional, Dict, Any
+from typing import Any, Dict, List, Optional
 
 from .base import Chunk
 

--- a/tests/handshakes/test_chroma_handshake.py
+++ b/tests/handshakes/test_chroma_handshake.py
@@ -1,6 +1,5 @@
 """Test the ChromaHandshake class."""
 import uuid
-from pathlib import Path
 from typing import List
 
 import pytest
@@ -8,11 +7,13 @@ import pytest
 # Try to import chromadb, skip tests if unavailable
 try:
     import chromadb
-    # Import the specific error type
-    from chromadb.errors import NotFoundError
+
     # Keep client types for reference but won't use for isinstance
     from chromadb import Client as ChromaClientType
     from chromadb import PersistentClient as ChromaPersistentClientType
+
+    # Import the specific error type
+    from chromadb.errors import NotFoundError
 except ImportError:
     chromadb = None
     # Define dummy types/exceptions if import fails
@@ -20,11 +21,11 @@ except ImportError:
     ChromaClientType = type(None)
     ChromaPersistentClientType = type(None)
 
+import chromadb
+
 from chonkie import ChromaHandshake
 from chonkie.friends.handshakes.chroma import ChromaEmbeddingFunction
 from chonkie.types import Chunk
-
-import chromadb
 
 # Mark all tests in this module to be skipped if chromadb is not installed
 pytestmark = pytest.mark.skipif(chromadb is None, reason="chromadb not installed")

--- a/tests/handshakes/test_qdrant_handshake.py
+++ b/tests/handshakes/test_qdrant_handshake.py
@@ -1,15 +1,16 @@
-import pytest
-import uuid
-from typing import List, Union
 import os
+import uuid
+from typing import List
+
+import pytest
 
 # Assuming qdrant_client is installed as per the request
 import qdrant_client
-from qdrant_client.http.models import Distance, PointStruct, VectorParams
+from qdrant_client.http.models import Distance, VectorParams
 
+from chonkie.embeddings import AutoEmbeddings, BaseEmbeddings
 from chonkie.friends.handshakes.qdrant import QdrantHandshake
 from chonkie.types import Chunk
-from chonkie.embeddings import AutoEmbeddings, BaseEmbeddings
 
 # Define the default model name for clarity
 DEFAULT_EMBEDDING_MODEL = "minishlab/potion-retrieval-32M"

--- a/tests/handshakes/test_qdrant_handshake.py
+++ b/tests/handshakes/test_qdrant_handshake.py
@@ -1,3 +1,4 @@
+"""Test the QdrantHandshake class."""
 import os
 import uuid
 from typing import List


### PR DESCRIPTION
This pull request introduces new chunking strategies, enhances optional dependencies, and improves code organization and documentation. The most significant changes include adding two new chunkers (`LateChunker` and `SDPMChunker`), restructuring optional dependencies in `pyproject.toml`, and refining documentation for better clarity.

### New Features:
* Added `LateChunker` class for late chunking via the Chonkie API, including methods for chunking text and creating instances from recipes (`src/chonkie/cloud/chunker/late.py`).
* Added `SDPMChunker` class for Semantic Double-Pass Merging, implementing advanced chunking logic with various configurable parameters (`src/chonkie/cloud/chunker/sdpm.py`).

### Dependency Management:
* Restructured optional dependencies in `pyproject.toml` to group them by functionality (e.g., chunkers, embeddings, etc.) and added new dependencies for the `LateChunker` and `SDPMChunker` (`pyproject.toml`).

### Code Organization:
* Updated `__init__.py` files to include the new chunkers (`LateChunker` and `SDPMChunker`) in the import and export lists (`src/chonkie/cloud/__init__.py`, `src/chonkie/cloud/chunker/__init__.py`). [[1]](diffhunk://#diff-d755310e35499ddbbf52812fca4020d8ee4f16ca454281516ec8769890295369R5-R7) [[2]](diffhunk://#diff-d755310e35499ddbbf52812fca4020d8ee4f16ca454281516ec8769890295369R19-R20) [[3]](diffhunk://#diff-3ba5ec3dca2b44fc8b4a2a2f4410f1782ee388d44112cf2253df4f3d8385d357R4-R6) [[4]](diffhunk://#diff-3ba5ec3dca2b44fc8b4a2a2f4410f1782ee388d44112cf2253df4f3d8385d357R17-R18)

### Documentation Improvements:
* Expanded the module-level docstring for the `Document` class to explain its purpose and potential use cases in hybrid chunking and metadata handling (`src/chonkie/types/document.py`).

### Minor Code Cleanups:
* Fixed import order and removed unused imports in several files to improve code readability and maintainability (`src/chonkie/friends/handshakes/turbopuffer.py`, `tests/handshakes/test_chroma_handshake.py`, `tests/handshakes/test_qdrant_handshake.py`). [[1]](diffhunk://#diff-0bc31a6f820ce4c055f3a7c1fdc907151870f3df1ebdc96a7aa1be453d200908L2-R5) [[2]](diffhunk://#diff-08e8fd2f4355ebedc16c7ea8f18dcb6868a61528022ae215694b379c244e2d95L3-L28) [[3]](diffhunk://#diff-f8fc3fd52c2efeb15f52f6071da53c30a609701043b3fded159ce54b394a6fcbL1-L12)