### PR TITLE
Fix: Handled unsupported languages in CodeChunker

### DIFF
--- a/src/chonkie/chunker/__init__.py
+++ b/src/chonkie/chunker/__init__.py
@@ -1,7 +1,7 @@
 """Module for chunkers."""
 
 from .base import BaseChunker
-from .code import CodeChunker
+from .code import CodeChunker, UnsupportedLanguageException
 from .late import LateChunker
 from .neural import NeuralChunker
 from .recursive import RecursiveChunker
@@ -20,6 +20,7 @@ __all__ = [
     "SDPMChunker",
     "LateChunker",
     "CodeChunker",
+    "UnsupportedLanguageException",
     "SlumberChunker",
     "NeuralChunker",
 ]

--- a/src/chonkie/chunker/code.py
+++ b/src/chonkie/chunker/code.py
@@ -364,7 +364,7 @@ class UnsupportedLanguageException(Exception):
         """Initialize the UnsupportedLanguageException."""
         if (language_detected):
             if (language_detected == 'txt'):
-                message = f"""
+                message = """
                 If the given input is a plain text and if you want to chunk plain text, please use the `RecursiveChunker` class or any other text chunking classes instead.
                 Refer: https://docs.chonkie.ai/python-sdk/chunkers/overview to know more about the available chunkers. 
                 Else, the given input language is not supported yet. Please contact support at support@chonkie.ai or raise an issue in Github. 

--- a/src/chonkie/chunker/code.py
+++ b/src/chonkie/chunker/code.py
@@ -366,18 +366,21 @@ class UnsupportedLanguageException(Exception):
             if (language_detected == 'txt'):
                 message = """
                 If the given input is a plain text and if you want to chunk plain text, please use the `RecursiveChunker` class or any other text chunking classes instead.
-                Refer: https://docs.chonkie.ai/python-sdk/chunkers/overview to know more about the available chunkers. 
+                Refer: https://docs.chonkie.ai/python-sdk/chunkers/overview to know more about the available chunkers.
+
+                If not, kindly try providing the language in the `language` parameter while initializing the CodeChunker class and check once again.
                 Else, the given input language is not supported yet. Please contact support at support@chonkie.ai or raise an issue in Github. 
                 """
             else:
                 message = f"""
-                The language detected: '{language_detected}' is not supported yet. Please contact support at support@chonkie.ai or raise an issue in Github.
+                Kindly try providing the language in the `language` parameter while initializing the CodeChunker class and check once again.
+                Else, the language: '{language_detected}' is not supported yet. Please contact support at support@chonkie.ai or raise an issue in Github.
                 """
         else:    
             if (language == "txt"):
                 message = """
                 Please use the `RecursiveChunker` class or any other text chunking classes instead.
-                Refer: https://docs.chonkie.ai/python-sdk/chunkers/overview to know more about the available chunkers. 
+                Refer: https://docs.chonkie.ai/python-sdk/chunkers/overview to know more about the available chunkers.
                 """
             else:
                 message = f"""

--- a/src/chonkie/chunker/code.py
+++ b/src/chonkie/chunker/code.py
@@ -374,6 +374,8 @@ class CodeChunker(BaseChunker):
         
 class UnsupportedLanguageException(Exception):
     """Raised when the detected language is not supported by the tree-sitter-language-pack."""
+
     def __init__(self, language: str):
+        """Initialize the UnsupportedLanguageException."""
         message = f"The language given or the detected language: '{language}' is not supported yet. Please contact support at support@chonkie.ai or raise an issue in Github."
         super().__init__(message)

--- a/tests/chunkers/test_code_chunker.py
+++ b/tests/chunkers/test_code_chunker.py
@@ -228,11 +228,15 @@ def test_code_chunker_chunking_unsupported_language(unsupported_language: str) -
     
     
 def test_code_chunker_chunking_plain_text(plain_text: str) -> None:
-    """Test if the CodeChunker is falling back to the RecursiveChunker if the input is detected as 'txt'."""
+    """Test if the CodeChunker is falling back to the RecursiveChunker if the input is detected as 'txt' or the language given is 'txt'."""
     chunk_size = 30
-    chunker = CodeChunker(language="auto", chunk_size=chunk_size)
-    chunks = chunker.chunk(plain_text)
+    with pytest.raises(UnsupportedLanguageException) as exc_info:
+        CodeChunker(language="txt", chunk_size=chunk_size)
+        
+    assert isinstance(exc_info.value, UnsupportedLanguageException)
     
-    assert isinstance(chunks, list)
-    assert len(chunks) > 0
-    assert all(isinstance(chunk, RecursiveChunk) for chunk in chunks)
+    chunker = CodeChunker(language="auto", chunk_size=chunk_size)
+    with pytest.raises(UnsupportedLanguageException) as exc_info:
+        chunker.chunk(plain_text)
+
+    assert isinstance(exc_info.value, UnsupportedLanguageException)

--- a/tests/chunkers/test_code_chunker.py
+++ b/tests/chunkers/test_code_chunker.py
@@ -3,7 +3,6 @@ import pytest
 
 from chonkie.chunker import CodeChunker, UnsupportedLanguageException
 from chonkie.types.code import CodeChunk
-from chonkie.types.recursive import RecursiveChunk
 
 
 @pytest.fixture

--- a/tests/chunkers/test_code_chunker.py
+++ b/tests/chunkers/test_code_chunker.py
@@ -53,8 +53,8 @@ console.log(calc.add(5, 3));
 
 @pytest.fixture
 def unsupported_code() -> str:
-    """
-    Return a sample ASP.NET code snippet.
+    """Return a sample ASP.NET code snippet.
+    
     ASP.NET is one of the languages that is not supported by the tree-sitter-language-pack yet.
     But, it can be detected by Magika.
     """
@@ -222,7 +222,7 @@ def test_code_chunker_chunking_unsupported_language(unsupported_language: str) -
     """Test if the UnsupportedLanguageException is being raised if an unsupported language is given."""
     chunk_size = 30
     with pytest.raises(UnsupportedLanguageException) as exc_info:
-        chunker = CodeChunker(language=unsupported_language, chunk_size=chunk_size)
+        CodeChunker(language=unsupported_language, chunk_size=chunk_size)
         
     assert isinstance(exc_info.value, UnsupportedLanguageException)
     


### PR DESCRIPTION
Things in the code:
1. Added a separate exception class `UnsupportedLanguageException` which will be raised whenever there is an unsupported input (detected language is unsupported when language is set to "auto") or an unsupported language. 
2. If the language detected by Magika is plain text ("txt") then, the CodeChunker falls back to the RecursiveChunker.
3. Added appropriate tests for the same.

Things to think about:
1. When the language is "auto", there is a possibility that Magika can't detect a language (for example, 'netlinx' which is available in the tree-sitter-language-packs is being detected as 'txt' by Magika). So, continuing the chunking process assuming plain text is a good approach. (Most of the languages which are unsupported by Magika are falling back to 'txt' based on my testing)

Refer [here](https://github.com/google/magika/blob/main/assets/models/standard_v3_3/README.md) to know the languages or tools which are supported by Magika. Refer [here](https://github.com/Goldziher/tree-sitter-language-pack/blob/main/tree_sitter_language_pack/__init__.py) to know the different bindings which are available in tree-sitter-language-pack. 