### PR TITLE
Feat: Add `URI` support via `provider://organization/model` style strings in `AutoEmbeddings`

### DIFF
--- a/src/chonkie/embeddings/auto.py
+++ b/src/chonkie/embeddings/auto.py
@@ -62,41 +62,47 @@ class AutoEmbeddings:
         if isinstance(model, BaseEmbeddings):
             return model
         elif isinstance(model, str):
+            # Initializing the embedding instance
             embeddings_instance = None
-            try:
+
+            # Check if the user passed in a provider alias
+            if "://" in model:
+                provider, model_name = model.split("://")
+                embeddings_cls = EmbeddingsRegistry.get_provider(provider)
+                if embeddings_cls:
+                    try:
+                        return embeddings_cls(model_name, **kwargs)  # type: ignore
+                    except Exception as error:
+                        raise ValueError(f"Failed to load {model} with {embeddings_cls.__name__}, with error: {error}")
+                else:
+                    raise ValueError(f"No provider found for {provider}. Please check the provider name and try again.")
+            else:
                 # Try to find matching implementation via registry
                 embeddings_cls = EmbeddingsRegistry.match(model)
                 if embeddings_cls:
-                    try:
-                        # Try instantiating with the model identifier
-                        embeddings_instance = embeddings_cls(model, **kwargs)  # type: ignore
-                    except Exception as e:
-                        warnings.warn(
-                            f"Failed to load {embeddings_cls.__name__} with model identifier: {e}. Trying fallback constructor."
-                        )
                         try:
-                            # Try instantiating without the model identifier
-                            embeddings_instance = embeddings_cls(**kwargs)
-                        except Exception as e2:
+                            # Try instantiating with the model identifier
+                            embeddings_instance = embeddings_cls(model, **kwargs)  # type: ignore
+                        except Exception as error:
                             warnings.warn(
-                                f"Fallback constructor {embeddings_cls.__name__}(**kwargs) also failed: {e2}. Proceeding to SentenceTransformer fallback."
+                                f"Failed to load {model} with {embeddings_cls.__name__}: {error}\n"
+                                f"Falling back to loading default provider model."
                             )
-                            # If both fail, embeddings_instance remains None, proceed to fallback
-                # If embeddings_cls is None, embeddings_instance remains None, proceed to fallback
-            except Exception as error:
-                warnings.warn(
-                    f"Error during registry lookup/instantiation: {error}. Falling back to SentenceTransformerEmbeddings."
-                )
-                # If registry lookup itself fails, embeddings_instance remains None, proceed to fallback
+                            try:
+                                # Try instantiating with the default provider model without the model identifier
+                                embeddings_instance = embeddings_cls(**kwargs)
+                            except Exception as error:
+                                warnings.warn(
+                                    f"Failed to load the default model for {embeddings_cls.__name__}: {error}\n"
+                                    f"Falling back to SentenceTransformerEmbeddings."
+                                )
 
             # If registry lookup and instantiation succeeded, return the instance
             if embeddings_instance:
                 return embeddings_instance
 
-            # Fallback to SentenceTransformerEmbeddings if registry failed or instantiation failed
-            warnings.warn("Falling back to SentenceTransformerEmbeddings.")
+            # If registry lookup and instantiation failed, return the default SentenceTransformerEmbeddings
             from .sentence_transformer import SentenceTransformerEmbeddings
-
             try:
                 return SentenceTransformerEmbeddings(model, **kwargs)
             except Exception as e:

--- a/src/chonkie/embeddings/model2vec.py
+++ b/src/chonkie/embeddings/model2vec.py
@@ -96,4 +96,4 @@ class Model2VecEmbeddings(BaseEmbeddings):
 
     def __repr__(self) -> str:
         """Representation of the Model2VecEmbeddings instance."""
-        return f"Model2VecEmbeddings(model_name_or_path={self.model_name_or_path})"
+        return f"Model2VecEmbeddings(model={self.model_name_or_path})"

--- a/src/chonkie/embeddings/registry.py
+++ b/src/chonkie/embeddings/registry.py
@@ -1,7 +1,6 @@
 """Registry for embedding implementations with pattern matching support."""
 
 import re
-from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Pattern, Type, Union
 
 from .base import BaseEmbeddings
@@ -13,27 +12,20 @@ from .sentence_transformer import SentenceTransformerEmbeddings
 from .voyageai import VoyageAIEmbeddings
 
 
-@dataclass
-class RegistryEntry:
-    """Registry entry containing the embeddings class and optional pattern."""
-
-    embeddings_cls: Type[BaseEmbeddings]
-    pattern: Optional[Pattern] = None
-    supported_types: Optional[List[str]] = None
-
-
 class EmbeddingsRegistry:
     """Registry for embedding implementations with pattern matching support."""
 
-    _registry: Dict[str, RegistryEntry] = {}
+    # Create a registry for the model names, provider aliases, patterns, and supported types
+    model_registry: Dict[str, Type[BaseEmbeddings]] = {}
+    provider_registry: Dict[str, Type[BaseEmbeddings]] = {}
+    pattern_registry: Dict[Pattern, Type[BaseEmbeddings]] = {}
+    type_registry: Dict[str, Type[BaseEmbeddings]] = {}
 
     @classmethod
-    def register(
+    def register_model(
         cls,
         name: str,
-        embedding_cls: Type[BaseEmbeddings],
-        pattern: Optional[Union[str, Pattern]] = None,
-        supported_types: Optional[List[str]] = None,
+        embedding_cls: Type[BaseEmbeddings]
     ) -> None:
         """Register a new embeddings implementation.
 
@@ -47,21 +39,61 @@ class EmbeddingsRegistry:
         if not issubclass(embedding_cls, BaseEmbeddings):
             raise ValueError(f"{embedding_cls} must be a subclass of BaseEmbeddings")
 
-        # Compile pattern if provided as string
-        if isinstance(pattern, str):
-            pattern = re.compile(pattern)
-
-        cls._registry[name] = RegistryEntry(
-            embeddings_cls=embedding_cls,
-            pattern=pattern,
-            supported_types=supported_types,
-        )
+        cls.model_registry[name] = embedding_cls
 
     @classmethod
-    def get(cls, name: str) -> Optional[Type[BaseEmbeddings]]:
-        """Get embeddings class by exact name match."""
-        entry = cls._registry.get(name)
-        return entry.embeddings_cls if entry else None
+    def register_provider(
+        cls,
+        alias: str,
+        embeddings_cls: Type[BaseEmbeddings],
+    ) -> None:
+        """Register a new provider.
+
+        Args:
+            alias: Unique identifier for this provider
+            embeddings_cls: The embeddings class to register
+
+        """
+        if not issubclass(embeddings_cls, BaseEmbeddings):
+            raise ValueError(f"{embeddings_cls} must be a subclass of BaseEmbeddings")
+
+        cls.provider_registry[alias] = embeddings_cls
+    
+    @classmethod
+    def register_pattern(
+        cls,
+        pattern: str,
+        embeddings_cls: Type[BaseEmbeddings]
+    ) -> None:
+        """Register a new pattern."""
+        if not issubclass(embeddings_cls, BaseEmbeddings):
+            raise ValueError(f"{embeddings_cls} must be a subclass of BaseEmbeddings")
+
+        pattern = re.compile(pattern)
+        cls.pattern_registry[pattern] = embeddings_cls
+
+    @classmethod
+    def register_types(
+        cls,
+        types: Union[str, List[str]],
+        embeddings_cls: Type[BaseEmbeddings]
+    ) -> None:
+        """Register a new type."""
+        if not issubclass(embeddings_cls, BaseEmbeddings):
+            raise ValueError(f"{embeddings_cls} must be a subclass of BaseEmbeddings")
+
+        if isinstance(types, str):
+            cls.type_registry[types] = embeddings_cls
+        elif isinstance(types, list):
+            for type in types:
+                cls.type_registry[type] = embeddings_cls
+        else:
+            raise ValueError(f"Invalid types: {types}")
+
+    @classmethod
+    def get_provider(cls, alias: str) -> Optional[Type[BaseEmbeddings]]:
+        """Get the embeddings class for a given provider alias."""
+        return cls.provider_registry.get(alias)
 
     @classmethod
     def match(cls, identifier: str) -> Optional[Type[BaseEmbeddings]]:
@@ -84,19 +116,24 @@ class EmbeddingsRegistry:
             cls.match("text-embedding-ada-002") -> OpenAIEmbeddings
 
         """
-        # First try exact match
-        if identifier in cls._registry:
-            return cls._registry[identifier].embeddings_cls
+        # Firstly, we'll try to see if the provider alias is provided
+        if "://" in identifier:
+            provider, model_name = identifier.split("://", 1)
+            if provider in cls.provider_registry:
+                return cls.provider_registry[provider]
 
-        # Then try patterns
-        for entry in cls._registry.values():
-            if entry.pattern and entry.pattern.match(identifier):
-                return entry.embeddings_cls
+        # Now, let's try to get a match from the model name
+        if identifier in cls.model_registry:
+            return cls.model_registry[identifier]
 
-        # if no match is found, raise ValueError
-        raise ValueError(
-            f"No matching embeddings implementation found for {identifier}"
-        )
+        # We couldn't match the model name and there's no provider alias mentioned either. 
+        # Let's try to get a match from the pattern registry
+        for pattern, embeddings_cls in cls.pattern_registry.items():
+            if pattern.match(identifier):
+                return embeddings_cls
+
+        # We couldn't find a proper match for the model name or the provider alias.
+        return None
 
     @classmethod
     def wrap(cls, object: Any, **kwargs: Any) -> BaseEmbeddings:
@@ -120,72 +157,69 @@ class EmbeddingsRegistry:
             return embeddings_cls(object, **kwargs)
         else:
             # Loop through all the registered embeddings and check if the object is an instance of any of them
-            for entry in cls._registry.values():
-                if entry.supported_types and any(
-                    t in str(type(object)) for t in entry.supported_types
-                ):
-                    return entry.embeddings_cls(object, **kwargs)
-
-            raise ValueError(f"Unsupported object type for embeddings: {object}")
-
-    @classmethod
-    def list_available(cls) -> List[str]:
-        """List names of available embeddings implementations."""
-        return [
-            name
-            for name, entry in cls._registry.items()
-            if entry.embeddings_cls.is_available()
-        ]
+            for type_alias, embeddings_cls in cls.type_registry.items():
+                if type_alias in str(type(object)):
+                    return embeddings_cls(object, **kwargs)
+        raise ValueError(f"Unsupported object type for embeddings: {object}")
 
 
 # Register all the available embeddings in the EmbeddingsRegistry!
 # This is essential for the `AutoEmbeddings` to work properly.
 
 # Register SentenceTransformer embeddings with pattern
-EmbeddingsRegistry.register(
-    "sentence-transformer",
+EmbeddingsRegistry.register_provider("st", SentenceTransformerEmbeddings)
+EmbeddingsRegistry.register_pattern(
+    r"^sentence-transformers/|^all-minilm-|^paraphrase-|^multi-qa-|^msmarco-",
     SentenceTransformerEmbeddings,
-    pattern=r"^sentence-transformers/|^all-minilm-|^paraphrase-|^multi-qa-|^msmarco-",
-    supported_types=["SentenceTransformer"],
 )
+EmbeddingsRegistry.register_types(
+    "SentenceTransformer",
+    SentenceTransformerEmbeddings,
+)
+EmbeddingsRegistry.register_model("all-minilm-l6-v2", SentenceTransformerEmbeddings)
+EmbeddingsRegistry.register_model("all-mpnet-base-v2", SentenceTransformerEmbeddings)
+EmbeddingsRegistry.register_model("multi-qa-mpnet-base-dot-v1", SentenceTransformerEmbeddings)
+# TODO: Add all the other SentenceTranformer models here as well!
 
 # Register OpenAI embeddings with pattern
-EmbeddingsRegistry.register(
-    "openai", OpenAIEmbeddings, pattern=r"^openai|^text-embedding-"
-)
-EmbeddingsRegistry.register("text-embedding-ada-002", OpenAIEmbeddings)
-EmbeddingsRegistry.register("text-embedding-3-small", OpenAIEmbeddings)
-EmbeddingsRegistry.register("text-embedding-3-large", OpenAIEmbeddings)
+EmbeddingsRegistry.register_provider("openai", OpenAIEmbeddings)
+EmbeddingsRegistry.register_pattern(r"^text-embedding-", OpenAIEmbeddings)
+EmbeddingsRegistry.register_model("text-embedding-ada-002", OpenAIEmbeddings)
+EmbeddingsRegistry.register_model("text-embedding-3-small", OpenAIEmbeddings)
+EmbeddingsRegistry.register_model("text-embedding-3-large", OpenAIEmbeddings)
 
 # Register model2vec embeddings
-EmbeddingsRegistry.register(
-    "model2vec",
-    Model2VecEmbeddings,
-    pattern=r"^minishlab/|^minishlab/potion-base-|^minishlab/potion-|^potion-",
-    supported_types=["Model2Vec", "model2vec"],
-)
+EmbeddingsRegistry.register_provider("model2vec", Model2VecEmbeddings)
+EmbeddingsRegistry.register_pattern(r"^minishlab/|^minishlab/potion-base-|^minishlab/potion-|^potion-", Model2VecEmbeddings)
+EmbeddingsRegistry.register_types("Model2Vec", Model2VecEmbeddings)
 
 # Register Cohere embeddings with pattern
-EmbeddingsRegistry.register("cohere", CohereEmbeddings, pattern=r"^cohere|^embed-")
-EmbeddingsRegistry.register("embed-english-v3.0", CohereEmbeddings)
-EmbeddingsRegistry.register("embed-multilingual-v3.0", CohereEmbeddings)
-EmbeddingsRegistry.register("embed-english-light-v3.0", CohereEmbeddings)
-EmbeddingsRegistry.register("embed-multilingual-light-v3.0", CohereEmbeddings)
-EmbeddingsRegistry.register("embed-english-v2.0", CohereEmbeddings)
-EmbeddingsRegistry.register("embed-english-light-v2.0", CohereEmbeddings)
-EmbeddingsRegistry.register("embed-multilingual-v2.0", CohereEmbeddings)
+EmbeddingsRegistry.register_provider("cohere", CohereEmbeddings)    
+EmbeddingsRegistry.register_pattern(r"^cohere|^embed-", CohereEmbeddings)
+EmbeddingsRegistry.register_model("embed-english-v3.0", CohereEmbeddings)
+EmbeddingsRegistry.register_model("embed-english-light-v3.0", CohereEmbeddings)
+EmbeddingsRegistry.register_model("embed-multilingual-light-v3.0", CohereEmbeddings)
+EmbeddingsRegistry.register_model("embed-english-v2.0", CohereEmbeddings)
+EmbeddingsRegistry.register_model("embed-english-light-v2.0", CohereEmbeddings)
+EmbeddingsRegistry.register_model("embed-multilingual-v2.0", CohereEmbeddings)
 
 # Register Jina embeddings
-EmbeddingsRegistry.register("jina", JinaEmbeddings, pattern=r"^jina|^jinaai")
-EmbeddingsRegistry.register("jina-embeddings-v3", JinaEmbeddings)
-
+EmbeddingsRegistry.register_provider("jina", JinaEmbeddings)
+EmbeddingsRegistry.register_pattern(r"^jina|^jinaai", JinaEmbeddings)
+EmbeddingsRegistry.register_model("jina-embeddings-v3", JinaEmbeddings)
+EmbeddingsRegistry.register_model("jina-embeddings-v2-base-en", JinaEmbeddings)
+EmbeddingsRegistry.register_model("jina-embeddings-v2-base-es", JinaEmbeddings)
+EmbeddingsRegistry.register_model("jina-embeddings-v2-base-de", JinaEmbeddings)
+EmbeddingsRegistry.register_model("jina-embeddings-v2-base-zh", JinaEmbeddings)
+EmbeddingsRegistry.register_model("jina-embeddings-v2-base-code", JinaEmbeddings)
 
 # Register Voyage embeddings
-EmbeddingsRegistry.register("voyageai", VoyageAIEmbeddings, pattern="^voyage|^voyageai")
-EmbeddingsRegistry.register("voyage-3-large", VoyageAIEmbeddings)
-EmbeddingsRegistry.register("voyage-3", VoyageAIEmbeddings)
-EmbeddingsRegistry.register("voyage-3-lite", VoyageAIEmbeddings)
-EmbeddingsRegistry.register("voyage-code-3", VoyageAIEmbeddings)
-EmbeddingsRegistry.register("voyage-finance-2", VoyageAIEmbeddings)
-EmbeddingsRegistry.register("voyage-law-2", VoyageAIEmbeddings)
-EmbeddingsRegistry.register("voyage-code-2", VoyageAIEmbeddings)
+EmbeddingsRegistry.register_provider("voyageai", VoyageAIEmbeddings)
+EmbeddingsRegistry.register_pattern(r"^voyage|^voyageai", VoyageAIEmbeddings)
+EmbeddingsRegistry.register_model("voyage-3-large", VoyageAIEmbeddings)
+EmbeddingsRegistry.register_model("voyage-3", VoyageAIEmbeddings)
+EmbeddingsRegistry.register_model("voyage-3-lite", VoyageAIEmbeddings)
+EmbeddingsRegistry.register_model("voyage-code-3", VoyageAIEmbeddings)
+EmbeddingsRegistry.register_model("voyage-finance-2", VoyageAIEmbeddings)
+EmbeddingsRegistry.register_model("voyage-law-2", VoyageAIEmbeddings)
+EmbeddingsRegistry.register_model("voyage-code-2", VoyageAIEmbeddings)


### PR DESCRIPTION
This pull request refactors the embedding registry and improves the `get_embeddings` method to enhance modularity, error handling, and support for provider aliases. Key changes include restructuring the registry to separate models, providers, patterns, and types, updating the `get_embeddings` logic to handle provider aliases, and simplifying error messages. Additionally, minor updates were made to improve code readability and maintainability.

### Enhancements to `get_embeddings` logic:
* Added support for provider aliases (e.g., `provider://model`) in the `get_embeddings` method, enabling more flexible model selection. Improved error handling with detailed messages for missing providers or failed instantiation. (`src/chonkie/embeddings/auto.py`, [src/chonkie/embeddings/auto.pyR65-L99](diffhunk://#diff-0e95a5656987bd1c00cac6f2cf536710a6262257c5a3a91a4a4f04608988b5cdR65-L99))

### Refactoring of the registry:
* Replaced the `RegistryEntry` dataclass with separate registries for models, providers, patterns, and types (`model_registry`, `provider_registry`, etc.), improving modularity and clarity. (`src/chonkie/embeddings/registry.py`, [src/chonkie/embeddings/registry.pyL16-R28](diffhunk://#diff-24ac16f8df6174d5a648298f8bd94c3736a99fe29ba0a84d38fdfd2b9ce5de23L16-R28))
* Introduced new methods (`register_model`, `register_provider`, `register_pattern`, `register_types`) for registering embeddings, replacing the previous `register` method. (`src/chonkie/embeddings/registry.py`, [src/chonkie/embeddings/registry.pyL50-R96](diffhunk://#diff-24ac16f8df6174d5a648298f8bd94c3736a99fe29ba0a84d38fdfd2b9ce5de23L50-R96))

### Updates to registry matching:
* Updated the `match` method to prioritize provider aliases, followed by model names and patterns, ensuring a more structured lookup process. (`src/chonkie/embeddings/registry.py`, [src/chonkie/embeddings/registry.pyL87-R136](diffhunk://#diff-24ac16f8df6174d5a648298f8bd94c3736a99fe29ba0a84d38fdfd2b9ce5de23L87-R136))
* Simplified the `wrap` method to use the `type_registry` for identifying embeddings based on object types. (`src/chonkie/embeddings/registry.py`, [src/chonkie/embeddings/registry.pyL123-R225](diffhunk://#diff-24ac16f8df6174d5a648298f8bd94c3736a99fe29ba0a84d38fdfd2b9ce5de23L123-R225))

### Minor improvements:
* Updated the `__repr__` method in `Model2VecEmbeddings` to use a more concise representation. (`src/chonkie/embeddings/model2vec.py`, [src/chonkie/embeddings/model2vec.pyL99-R99](diffhunk://#diff-7567a68d2e120b898523d55da2af93d790a3030646dedf36d2914d9d2c5b2c31L99-R99))
* Removed unused imports (e.g., `dataclasses`) to clean up the codebase. (`src/chonkie/embeddings/registry.py`, [src/chonkie/embeddings/registry.pyL4](diffhunk://#diff-24ac16f8df6174d5a648298f8bd94c3736a99fe29ba0a84d38fdfd2b9ce5de23L4))