### PR TITLE
Fix: `OverlapRefinery` is caching too much; revert `context_size` calculation caching

### DIFF
--- a/src/chonkie/refinery/overlap.py
+++ b/src/chonkie/refinery/overlap.py
@@ -73,7 +73,6 @@ class OverlapRefinery(BaseRefinery):
         # Performance optimization: Add caches for repeated operations
         self._token_cache: Dict[str, list] = {}  # Cache for tokenizer.encode() results
         self._count_cache: Dict[str, int] = {}  # Cache for token count results
-        self._calculated_context_size: Union[int, None] = None  # Cache for float context size calculation
 
 
     def _is_available(self) -> bool:
@@ -388,11 +387,9 @@ class OverlapRefinery(BaseRefinery):
             chunks: The chunks to get the overlap context size for.
 
         """
-        # Performance optimization: Cache float context size calculation
+        # Calculate context size for each call (float context size depends on chunk set)
         if isinstance(self.context_size, float):
-            if self._calculated_context_size is None:
-                self._calculated_context_size = int(self.context_size * max(chunk.token_count for chunk in chunks))
-            return self._calculated_context_size
+            return int(self.context_size * max(chunk.token_count for chunk in chunks))
         else:
             return self.context_size
 

--- a/src/chonkie/refinery/overlap.py
+++ b/src/chonkie/refinery/overlap.py
@@ -79,7 +79,7 @@ class OverlapRefinery(BaseRefinery):
         """Check if the refinery is available."""
         return True
 
-    def _split_text(self, text: str, recursive_level: RecursiveLevel) -> list[str]:
+    def _split_text(self, text: str, recursive_level: RecursiveLevel, effective_context_size: int) -> list[str]:
         """Split the text into chunks using the delimiters."""
         # At every delimiter, replace it with the sep
         if recursive_level.whitespace:
@@ -98,10 +98,9 @@ class OverlapRefinery(BaseRefinery):
         else:
             # Encode, Split, and Decode
             encoded = self.tokenizer.encode(text)
-            context_size_int = int(self.context_size) if isinstance(self.context_size, (int, float)) else self.context_size
             token_splits = [
-                encoded[i : i + context_size_int]
-                for i in range(0, len(encoded), context_size_int)]
+                encoded[i : i + effective_context_size]
+                for i in range(0, len(encoded), effective_context_size)]
             splits = list(self.tokenizer.decode_batch(token_splits))
 
         # Some splits may not be meaningful yet.
@@ -137,12 +136,13 @@ class OverlapRefinery(BaseRefinery):
         cached_counts.sort(key=lambda x: x[0])
         return [count for _, count in cached_counts]
 
-    def _group_splits(self, splits: List[str], token_counts: List[int]) -> List[str]:
+    def _group_splits(self, splits: List[str], token_counts: List[int], effective_context_size: int) -> List[str]:
         """Group the splits.
 
         Args:
             splits: The splits to merge.
             token_counts: The token counts of the splits.
+            effective_context_size: The effective context size to use.
 
         Returns:
             The grouped splits.
@@ -151,7 +151,7 @@ class OverlapRefinery(BaseRefinery):
         group = []
         current_token_count = 0
         for token_count, split in zip(token_counts, splits):
-            if current_token_count + token_count < self.context_size:
+            if current_token_count + token_count < effective_context_size:
                 group.append(split)
                 current_token_count += token_count
             else:
@@ -159,7 +159,7 @@ class OverlapRefinery(BaseRefinery):
         return group
 
 
-    def _prefix_overlap_token(self, chunk: Chunk) -> str:
+    def _prefix_overlap_token(self, chunk: Chunk, effective_context_size: int) -> str:
         """Calculate token-based overlap context using tokenizer.
 
         Takes a larger window of text from the chunk end, tokenizes it,
@@ -167,6 +167,7 @@ class OverlapRefinery(BaseRefinery):
 
         Args:
             chunk: The chunk to calculate the overlap context for.
+            effective_context_size: The effective context size to use.
 
         Returns:
             The overlap context.
@@ -179,20 +180,20 @@ class OverlapRefinery(BaseRefinery):
             tokens = self.tokenizer.encode(chunk.text)
             self._token_cache[chunk.text] = tokens
             
-        if self.context_size > len(tokens):
+        if effective_context_size > len(tokens):
             warnings.warn("Context size is greater than the chunk size. The entire chunk will be returned as the context.")
             return chunk.text
         else:
-            assert isinstance(self.context_size, int), "Context size must be an integer."
-            return self.tokenizer.decode(tokens[-self.context_size:])
+            return self.tokenizer.decode(tokens[-effective_context_size:])
     
-    def _recursive_overlap(self, text: str, level: int, method: Literal["prefix", "suffix"]) -> str:
+    def _recursive_overlap(self, text: str, level: int, method: Literal["prefix", "suffix"], effective_context_size: int) -> str:
         """Calculate recursive overlap context.
         
         Args:
             text: The text to calculate the overlap context for.
             level: The recursive level to use.
             method: The method to use for the context.
+            effective_context_size: The effective context size to use.
         
         Returns:
             The overlap context.
@@ -209,7 +210,7 @@ class OverlapRefinery(BaseRefinery):
         recursive_level = self.rules[level]
         if recursive_level is None:
             return text
-        splits = self._split_text(text, recursive_level)
+        splits = self._split_text(text, recursive_level, effective_context_size)
 
         if method == "prefix":
             splits = splits[::-1]
@@ -218,11 +219,11 @@ class OverlapRefinery(BaseRefinery):
         token_counts = self._get_token_counts_cached(splits)
 
         # Group the splits
-        grouped_splits = self._group_splits(splits, token_counts)
+        grouped_splits = self._group_splits(splits, token_counts, effective_context_size)
 
         # If the grouped splits is empty, then we need to recursively split the first split
         if not grouped_splits:
-            return self._recursive_overlap(splits[0], level+1, method)
+            return self._recursive_overlap(splits[0], level+1, method, effective_context_size)
 
         if method == "prefix":
             grouped_splits = grouped_splits[::-1]
@@ -232,35 +233,44 @@ class OverlapRefinery(BaseRefinery):
         return context
 
     
-    def _prefix_overlap_recursive(self, chunk: Chunk) -> str:
+    def _prefix_overlap_recursive(self, chunk: Chunk, effective_context_size: int) -> str:
         """Calculate recursive overlap context.
 
         Takes a larger window of text from the chunk end, tokenizes it,
         and selects exactly context_size tokens worth of text.
+
+        Args:
+            chunk: The chunk to calculate the overlap context for.
+            effective_context_size: The effective context size to use.
+
+        Returns:
+            The overlap context.
         
         """
-        return self._recursive_overlap(chunk.text, 0, "prefix")
+        return self._recursive_overlap(chunk.text, 0, "prefix", effective_context_size)
 
-    def _get_prefix_overlap_context(self, chunk: Chunk) -> str:
+    def _get_prefix_overlap_context(self, chunk: Chunk, effective_context_size: int) -> str:
         """Get the prefix overlap context.
 
         Args:
             chunk: The chunk to get the prefix overlap context for.
+            effective_context_size: The effective context size to use.
 
         """
         # Route to the appropriate method
         if self.mode == "token":
-            return self._prefix_overlap_token(chunk)
+            return self._prefix_overlap_token(chunk, effective_context_size)
         elif self.mode == "recursive":
-            return self._prefix_overlap_recursive(chunk)
+            return self._prefix_overlap_recursive(chunk, effective_context_size)
         else:
             raise ValueError("Mode must be one of: token, recursive.")
 
-    def _refine_prefix(self, chunks: List[Chunk]) -> List[Chunk]:
+    def _refine_prefix(self, chunks: List[Chunk], effective_context_size: int) -> List[Chunk]:
         """Refine the prefix of the chunk.
         
         Args:
             chunks: The chunks to refine.
+            effective_context_size: The effective context size to use.
 
         Returns:
             The refined chunks.
@@ -272,7 +282,7 @@ class OverlapRefinery(BaseRefinery):
             prev_chunk = chunks[i]
 
             # Calculate the overlap context
-            context = self._get_prefix_overlap_context(prev_chunk)
+            context = self._get_prefix_overlap_context(prev_chunk, effective_context_size)
 
             # Set it as a part of the chunk
             setattr(chunk, "context", context)
@@ -296,11 +306,18 @@ class OverlapRefinery(BaseRefinery):
         return chunks
 
 
-    def _suffix_overlap_token(self, chunk: Chunk) -> str:
+    def _suffix_overlap_token(self, chunk: Chunk, effective_context_size: int) -> str:
         """Calculate token-based overlap context using tokenizer.
 
         Takes a larger window of text from the chunk start, tokenizes it,
         and selects exactly context_size tokens worth of text.
+
+        Args:
+            chunk: The chunk to calculate the overlap context for.
+            effective_context_size: The effective context size to use.
+
+        Returns:
+            The overlap context.
         
         """
         # Performance optimization: Cache tokenization results
@@ -310,42 +327,50 @@ class OverlapRefinery(BaseRefinery):
             tokens = self.tokenizer.encode(chunk.text)
             self._token_cache[chunk.text] = tokens
             
-        if self.context_size > len(tokens):
+        if effective_context_size > len(tokens):
             warnings.warn("Context size is greater than the chunk size. The entire chunk will be returned as the context.")
             return chunk.text
         else:
-            assert isinstance(self.context_size, int), "Context size must be an integer."
-            return self.tokenizer.decode(tokens[:self.context_size])
+            return self.tokenizer.decode(tokens[:effective_context_size])
     
-    def _suffix_overlap_recursive(self, chunk: Chunk) -> str:
+    def _suffix_overlap_recursive(self, chunk: Chunk, effective_context_size: int) -> str:
         """Calculate recursive overlap context.
 
         Takes a larger window of text from the chunk start, tokenizes it,
         and selects exactly context_size tokens worth of text.
+
+        Args:
+            chunk: The chunk to calculate the overlap context for.
+            effective_context_size: The effective context size to use.
+
+        Returns:
+            The overlap context.
         
         """
-        return self._recursive_overlap(chunk.text, 0, "suffix")
+        return self._recursive_overlap(chunk.text, 0, "suffix", effective_context_size)
 
-    def _get_suffix_overlap_context(self, chunk: Chunk) -> str:
+    def _get_suffix_overlap_context(self, chunk: Chunk, effective_context_size: int) -> str:
         """Get the suffix overlap context.
 
         Args:
             chunk: The chunk to get the suffix overlap context for.
+            effective_context_size: The effective context size to use.
 
         """
         # Route to the appropriate method
         if self.mode == "token":
-            return self._suffix_overlap_token(chunk)
+            return self._suffix_overlap_token(chunk, effective_context_size)
         elif self.mode == "recursive":
-            return self._suffix_overlap_recursive(chunk)
+            return self._suffix_overlap_recursive(chunk, effective_context_size)
         else:
             raise ValueError("Mode must be one of: token, recursive.")
 
-    def _refine_suffix(self, chunks: List[Chunk]) -> List[Chunk]:
+    def _refine_suffix(self, chunks: List[Chunk], effective_context_size: int) -> List[Chunk]:
         """Refine the suffix of the chunk.
         
         Args:
             chunks: The chunks to refine.
+            effective_context_size: The effective context size to use.
 
         Returns:
             The refined chunks.
@@ -357,7 +382,7 @@ class OverlapRefinery(BaseRefinery):
             prev_chunk = chunks[i+1]
 
             # Calculate the overlap context
-            context = self._get_suffix_overlap_context(prev_chunk)
+            context = self._get_suffix_overlap_context(prev_chunk, effective_context_size)
 
             # Set it as a part of the chunk
             setattr(chunk, "context", context)
@@ -416,14 +441,14 @@ class OverlapRefinery(BaseRefinery):
         if not self.inplace:
             chunks = [chunk.copy() for chunk in chunks]
         
-        # Get a rough estimate of the overlap if the context size is a float
-        self.context_size = self._get_overlap_context_size(chunks)
+        # Get the effective context size for this chunk set (don't overwrite self.context_size)
+        effective_context_size = self._get_overlap_context_size(chunks)
 
         # Refine the chunks based on the method
         if self.method == "prefix":
-            return self._refine_prefix(chunks)
+            return self._refine_prefix(chunks, effective_context_size)
         elif self.method == "suffix":
-            return self._refine_suffix(chunks)
+            return self._refine_suffix(chunks, effective_context_size)
         else:
             raise ValueError("Method must be one of: prefix, suffix.")
         

--- a/tests/refinery/test_embedding_refinery.py
+++ b/tests/refinery/test_embedding_refinery.py
@@ -1,0 +1,350 @@
+"""Test the EmbeddingsRefinery module."""
+
+import pytest
+from typing import TYPE_CHECKING, Callable
+from unittest.mock import Mock, patch
+
+from chonkie.embeddings import BaseEmbeddings
+from chonkie.refinery import EmbeddingsRefinery
+from chonkie.types import Chunk
+
+if TYPE_CHECKING:
+    import numpy as np
+
+
+class MockEmbeddings(BaseEmbeddings):
+    """Mock embeddings class for testing."""
+    
+    def __init__(self, dimension: int = 128, available: bool = True):
+        """Initialize MockEmbeddings."""
+        self._dimension = dimension
+        self._available = available
+        # Skip the parent __init__ to avoid dependency checks
+    
+    def _is_available(self) -> bool:
+        """Check if mock embeddings are available."""
+        return self._available
+    
+    def embed(self, text: str) -> "np.ndarray":
+        """Mock embed method."""
+        import numpy as np
+        # Simple mock: return array of floats based on text length
+        return np.array([float(i % 10) for i in range(self._dimension)], dtype=np.float32)
+    
+    def embed_batch(self, texts: list[str]) -> list["np.ndarray"]:
+        """Mock batch embed method."""
+        return [self.embed(text) for text in texts]
+    
+    @property
+    def dimension(self) -> int:
+        """Mock dimension property."""
+        return self._dimension
+    
+    def count_tokens(self, text: str) -> int:
+        """Mock token counting method."""
+        # Simple mock: split by whitespace
+        return len(text.split())
+    
+    def get_tokenizer_or_token_counter(self) -> Callable[[str], int]:
+        """Return the token counter function."""
+        return self.count_tokens
+
+
+@pytest.fixture
+def sample_chunks() -> list[Chunk]:
+    """Fixture to create sample chunks."""
+    return [
+        Chunk(text="This is the first chunk.", start_index=0, end_index=24, token_count=5),
+        Chunk(text="This is the second chunk.", start_index=25, end_index=49, token_count=5),
+        Chunk(text="This is the third chunk.", start_index=50, end_index=74, token_count=5),
+    ]
+
+
+@pytest.fixture
+def mock_embeddings() -> MockEmbeddings:
+    """Fixture to create mock embeddings."""
+    return MockEmbeddings(dimension=128, available=True)
+
+
+def test_embeddings_refinery_initialization_with_string() -> None:
+    """Test EmbeddingsRefinery initialization with string model name."""
+    with patch('chonkie.embeddings.AutoEmbeddings.get_embeddings') as mock_get:
+        mock_get.return_value = MockEmbeddings()
+        
+        refinery = EmbeddingsRefinery("test-model")
+        
+        assert refinery is not None
+        assert isinstance(refinery, EmbeddingsRefinery)
+        mock_get.assert_called_once_with("test-model")
+
+
+def test_embeddings_refinery_initialization_with_string_and_kwargs() -> None:
+    """Test EmbeddingsRefinery initialization with string model and kwargs."""
+    with patch('chonkie.embeddings.AutoEmbeddings.get_embeddings') as mock_get:
+        mock_get.return_value = MockEmbeddings()
+        
+        kwargs = {"batch_size": 32, "device": "cpu"}
+        refinery = EmbeddingsRefinery("test-model", **kwargs)
+        
+        assert refinery is not None
+        mock_get.assert_called_once_with("test-model", **kwargs)
+
+
+def test_embeddings_refinery_initialization_with_embeddings_instance(mock_embeddings: MockEmbeddings) -> None:
+    """Test EmbeddingsRefinery initialization with BaseEmbeddings instance."""
+    refinery = EmbeddingsRefinery(mock_embeddings)
+    
+    assert refinery is not None
+    assert isinstance(refinery, EmbeddingsRefinery)
+    assert refinery.embedding_model is mock_embeddings
+
+
+def test_embeddings_refinery_initialization_with_invalid_type() -> None:
+    """Test EmbeddingsRefinery initialization with invalid model type."""
+    with pytest.raises(ValueError, match="Model must be a string or a BaseEmbeddings instance"):
+        EmbeddingsRefinery(123)  # Invalid type
+    
+    with pytest.raises(ValueError, match="Model must be a string or a BaseEmbeddings instance"):
+        EmbeddingsRefinery(["not", "valid"])  # Invalid type
+
+
+def test_embeddings_refinery_is_available(mock_embeddings: MockEmbeddings) -> None:
+    """Test EmbeddingsRefinery._is_available method."""
+    refinery = EmbeddingsRefinery(mock_embeddings)
+    assert refinery._is_available() is True
+    
+    # Test with unavailable embeddings
+    unavailable_embeddings = MockEmbeddings(available=False)
+    refinery_unavailable = EmbeddingsRefinery(unavailable_embeddings)
+    assert refinery_unavailable._is_available() is False
+
+
+def test_embeddings_refinery_refine_basic(mock_embeddings: MockEmbeddings, sample_chunks: list[Chunk]) -> None:
+    """Test basic refine functionality."""
+    refinery = EmbeddingsRefinery(mock_embeddings)
+    
+    # Ensure chunks don't have embeddings initially
+    for chunk in sample_chunks:
+        assert not hasattr(chunk, 'embedding')
+    
+    refined_chunks = refinery.refine(sample_chunks)
+    
+    # Check that embeddings were added
+    assert len(refined_chunks) == 3
+    for chunk in refined_chunks:
+        assert hasattr(chunk, 'embedding')
+        import numpy as np
+        assert isinstance(chunk.embedding, np.ndarray)
+        assert chunk.embedding.shape == (128,)  # Mock dimension
+        assert chunk.embedding.dtype == np.float32
+
+
+def test_embeddings_refinery_refine_empty_list(mock_embeddings: MockEmbeddings) -> None:
+    """Test refine with empty chunk list."""
+    refinery = EmbeddingsRefinery(mock_embeddings)
+    
+    empty_chunks = []
+    refined_chunks = refinery.refine(empty_chunks)
+    
+    assert refined_chunks == []
+    assert len(refined_chunks) == 0
+
+
+def test_embeddings_refinery_refine_single_chunk(mock_embeddings: MockEmbeddings) -> None:
+    """Test refine with single chunk."""
+    refinery = EmbeddingsRefinery(mock_embeddings)
+    
+    single_chunk = [Chunk(text="Single chunk", start_index=0, end_index=11, token_count=2)]
+    refined_chunks = refinery.refine(single_chunk)
+    
+    assert len(refined_chunks) == 1
+    assert hasattr(refined_chunks[0], 'embedding')
+    import numpy as np
+    assert isinstance(refined_chunks[0].embedding, np.ndarray)
+    assert refined_chunks[0].embedding.shape == (128,)
+
+
+def test_embeddings_refinery_refine_preserves_chunk_properties(mock_embeddings: MockEmbeddings) -> None:
+    """Test that refine preserves all original chunk properties."""
+    refinery = EmbeddingsRefinery(mock_embeddings)
+    
+    chunk = Chunk(text="Test chunk", start_index=10, end_index=19, token_count=2)
+    original_text = chunk.text
+    original_start = chunk.start_index
+    original_end = chunk.end_index
+    original_token_count = chunk.token_count
+    
+    refined_chunks = refinery.refine([chunk])
+    refined_chunk = refined_chunks[0]
+    
+    # Check that original properties are preserved
+    assert refined_chunk.text == original_text
+    assert refined_chunk.start_index == original_start
+    assert refined_chunk.end_index == original_end
+    assert refined_chunk.token_count == original_token_count
+    
+    # Check that embedding was added
+    assert hasattr(refined_chunk, 'embedding')
+
+
+def test_embeddings_refinery_dimension_property(mock_embeddings: MockEmbeddings) -> None:
+    """Test dimension property."""
+    refinery = EmbeddingsRefinery(mock_embeddings)
+    
+    assert refinery.dimension == 128
+    
+    # Test with different dimension
+    different_embeddings = MockEmbeddings(dimension=256)
+    refinery_256 = EmbeddingsRefinery(different_embeddings)
+    assert refinery_256.dimension == 256
+
+
+def test_embeddings_refinery_repr(mock_embeddings: MockEmbeddings) -> None:
+    """Test __repr__ method."""
+    refinery = EmbeddingsRefinery(mock_embeddings)
+    repr_str = repr(refinery)
+    
+    assert "EmbeddingsRefinery" in repr_str
+    assert "embedding_model=" in repr_str
+    assert isinstance(repr_str, str)
+
+
+def test_embeddings_refinery_embed_batch_called_correctly(mock_embeddings: MockEmbeddings, sample_chunks: list[Chunk]) -> None:
+    """Test that embed_batch is called with correct texts."""
+    # Spy on the embed_batch method
+    original_embed_batch = mock_embeddings.embed_batch
+    mock_embeddings.embed_batch = Mock(side_effect=original_embed_batch)
+    
+    refinery = EmbeddingsRefinery(mock_embeddings)
+    refinery.refine(sample_chunks)
+    
+    # Check that embed_batch was called once with the correct texts
+    mock_embeddings.embed_batch.assert_called_once()
+    called_texts = mock_embeddings.embed_batch.call_args[0][0]
+    expected_texts = [chunk.text for chunk in sample_chunks]
+    assert called_texts == expected_texts
+
+
+def test_embeddings_refinery_with_different_chunk_types() -> None:
+    """Test refinery with different chunk types."""
+    from chonkie.types import RecursiveChunk, SentenceChunk
+    
+    mock_embeddings = MockEmbeddings()
+    refinery = EmbeddingsRefinery(mock_embeddings)
+    
+    # Mix of different chunk types
+    chunks = [
+        Chunk(text="Regular chunk", start_index=0, end_index=12, token_count=2),
+        RecursiveChunk(text="Recursive chunk", start_index=13, end_index=27, token_count=2, level=1),
+        SentenceChunk(text="Sentence chunk", start_index=28, end_index=41, token_count=2),
+    ]
+    
+    refined_chunks = refinery.refine(chunks)
+    
+    # All chunks should get embeddings regardless of type
+    assert len(refined_chunks) == 3
+    for chunk in refined_chunks:
+        assert hasattr(chunk, 'embedding')
+        import numpy as np
+        assert isinstance(chunk.embedding, np.ndarray)
+
+
+def test_embeddings_refinery_large_batch(mock_embeddings: MockEmbeddings) -> None:
+    """Test refinery with large batch of chunks."""
+    # Create 100 chunks
+    large_chunks = [
+        Chunk(text=f"Chunk number {i}", start_index=i*20, end_index=(i+1)*20-1, token_count=3)
+        for i in range(100)
+    ]
+    
+    refinery = EmbeddingsRefinery(mock_embeddings)
+    refined_chunks = refinery.refine(large_chunks)
+    
+    assert len(refined_chunks) == 100
+    for chunk in refined_chunks:
+        assert hasattr(chunk, 'embedding')
+        import numpy as np
+        assert isinstance(chunk.embedding, np.ndarray)
+        assert chunk.embedding.shape == (128,)
+
+
+def test_embeddings_refinery_with_empty_text_chunks(mock_embeddings: MockEmbeddings) -> None:
+    """Test refinery with chunks containing empty or whitespace text."""
+    chunks = [
+        Chunk(text="", start_index=0, end_index=0, token_count=0),
+        Chunk(text="   ", start_index=1, end_index=3, token_count=0),
+        Chunk(text="Normal text", start_index=4, end_index=14, token_count=2),
+    ]
+    
+    refinery = EmbeddingsRefinery(mock_embeddings)
+    refined_chunks = refinery.refine(chunks)
+    
+    assert len(refined_chunks) == 3
+    for chunk in refined_chunks:
+        assert hasattr(chunk, 'embedding')
+
+
+def test_embeddings_refinery_modifies_chunks_inplace(mock_embeddings: MockEmbeddings) -> None:
+    """Test that refinery modifies chunks in place."""
+    refinery = EmbeddingsRefinery(mock_embeddings)
+    
+    original_chunks = [
+        Chunk(text="Test chunk 1", start_index=0, end_index=11, token_count=2),
+        Chunk(text="Test chunk 2", start_index=12, end_index=23, token_count=2),
+    ]
+    
+    # Keep references to original chunks
+    chunk1_ref = original_chunks[0]
+    chunk2_ref = original_chunks[1]
+    
+    refined_chunks = refinery.refine(original_chunks)
+    
+    # Should return the same objects (modified in place)
+    assert refined_chunks is original_chunks
+    assert refined_chunks[0] is chunk1_ref
+    assert refined_chunks[1] is chunk2_ref
+    
+    # Original chunk objects should now have embeddings
+    assert hasattr(chunk1_ref, 'embedding')
+    assert hasattr(chunk2_ref, 'embedding')
+
+
+def test_embeddings_refinery_embedding_consistency(mock_embeddings: MockEmbeddings) -> None:
+    """Test that same text produces same embeddings."""
+    refinery = EmbeddingsRefinery(mock_embeddings)
+    
+    # Create chunks with same text
+    chunks1 = [Chunk(text="Same text", start_index=0, end_index=8, token_count=2)]
+    chunks2 = [Chunk(text="Same text", start_index=10, end_index=18, token_count=2)]
+    
+    refined1 = refinery.refine(chunks1)
+    refined2 = refinery.refine(chunks2)
+    
+    # Same text should produce same embeddings
+    import numpy as np
+    assert np.array_equal(refined1[0].embedding, refined2[0].embedding)
+
+
+@pytest.mark.skipif(
+    True,  # Skip by default since it requires actual model
+    reason="Requires actual embedding model - enable for integration testing"
+)
+def test_embeddings_refinery_with_real_model() -> None:
+    """Integration test with real embedding model."""
+    # This test can be enabled for integration testing with real models
+    refinery = EmbeddingsRefinery("sentence-transformers/all-MiniLM-L6-v2")
+    
+    chunks = [
+        Chunk(text="Hello world", start_index=0, end_index=10, token_count=2),
+        Chunk(text="How are you", start_index=11, end_index=21, token_count=3),
+    ]
+    
+    if refinery._is_available():
+        refined_chunks = refinery.refine(chunks)
+        
+        for chunk in refined_chunks:
+            assert hasattr(chunk, 'embedding')
+            import numpy as np
+            assert isinstance(chunk.embedding, np.ndarray)
+            assert chunk.embedding.shape[0] > 0
+            assert chunk.embedding.dtype in [np.float32, np.float64]


### PR DESCRIPTION
This pull request addresses a bug in the `OverlapRefinery` class where a cached context size caused incorrect behavior when reusing the class with different chunk sets. The changes remove the caching mechanism for the calculated context size and add a new test to ensure correctness.

### Bug Fixes:
* Removed the `_calculated_context_size` cache from the `OverlapRefinery` class to ensure that the context size is recalculated for each set of chunks when `context_size` is a float. (`src/chonkie/refinery/overlap.py`, [[1]](diffhunk://#diff-80725268365cb5d6bae898943f18604b84bce3021014d1406a3db4d9bfa4723bL76) [[2]](diffhunk://#diff-80725268365cb5d6bae898943f18604b84bce3021014d1406a3db4d9bfa4723bL391-R392)

### Tests:
* Added a new test, `test_overlap_refinery_context_size_reuse_correctness`, to validate that the `OverlapRefinery` correctly calculates different context sizes for different chunk sets when reusing the class. This ensures the bug is resolved. (`tests/refinery/test_overlap_refinery.py`, [tests/refinery/test_overlap_refinery.pyR711-R748](diffhunk://#diff-1e647a929d303b05d9c81c996c63116bd9f4980c44d57707c1a471727b5b7302R711-R748))