### PR TITLE
Fix: `cython` module build failing during CD — Add `cython` build info to `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,7 +140,15 @@ packages = [
 ]
 
 [tool.setuptools.package-data]
-"chonkie.chunker.c_extensions" = ["*.pyx", "*.pxd"]
+"chonkie.chunker.c_extensions" = ["*.pyx", "*.pxd", "*.c", "*.so"]
+
+[[tool.setuptools.ext-modules]]
+name = "chonkie.chunker.c_extensions.split"
+sources = ["src/chonkie/chunker/c_extensions/split.pyx"]
+
+[[tool.setuptools.ext-modules]]
+name = "chonkie.chunker.c_extensions.merge"
+sources = ["src/chonkie/chunker/c_extensions/merge.pyx"]
 
 [tool.setuptools.dynamic]
 version = {attr = "chonkie.__version__"}


### PR DESCRIPTION
This pull request updates the `pyproject.toml` file to enhance the build configuration for the `chonkie.chunker.c_extensions` package. The changes include extending the package data and defining new Cython extension modules.

### Build configuration updates:

* Expanded the `package-data` for `chonkie.chunker.c_extensions` to include additional file types (`*.c` and `*.so`).
* Added two new Cython extension modules:
  - `chonkie.chunker.c_extensions.split`, with source file `src/chonkie/chunker/c_extensions/split.pyx`.
  - `chonkie.chunker.c_extensions.merge`, with source file `src/chonkie/chunker/c_extensions/merge.pyx`.