### PR TITLE
Fix: Use `cibuildwheel` to build and publish wheels to PyPI

### DIFF
--- a/.github/workflows/python-publish-wheels.yml
+++ b/.github/workflows/python-publish-wheels.yml
@@ -1,0 +1,62 @@
+# This workflow builds wheels using cibuildwheel for proper manylinux support
+# Use this instead of python-publish.yml for packages with C extensions
+
+name: Build and Upload Python Wheels
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-13, macos-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.16.5
+        env:
+          CIBW_BUILD: cp39-* cp310-* cp311-* cp312-* cp313-*
+          CIBW_SKIP: "*-win32 *-manylinux_i686"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
+          path: ./wheelhouse/*.whl
+
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build sdist
+        run: pipx run build --sdist
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cibw-sdist
+          path: dist/*.tar.gz
+
+  upload_pypi:
+    needs: [build_wheels, build_sdist]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: cibw-*
+          path: dist
+          merge-multiple: true
+
+      - uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -6,33 +6,33 @@
 # separate terms of service, privacy policy, and support
 # documentation.
 
-name: Upload Python Package
+# name: Upload Python Package
 
-on:
-  release:
-    types: [published]
+# on:
+#   release:
+#     types: [published]
 
-permissions:
-  contents: read
+# permissions:
+#   contents: read
 
-jobs:
-  deploy:
-    runs-on: ubuntu-latest
+# jobs:
+#   deploy:
+#     runs-on: ubuntu-latest
 
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v3
-        with:
-          python-version: "3.x"
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install build
-      - name: Build package
-        run: python -m build
-      - name: Publish package
-        uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
+#     steps:
+#       - uses: actions/checkout@v4
+#       - name: Set up Python
+#         uses: actions/setup-python@v3
+#         with:
+#           python-version: "3.x"
+#       - name: Install dependencies
+#         run: |
+#           python -m pip install --upgrade pip
+#           pip install build
+#       - name: Build package
+#         run: python -m build
+#       - name: Publish package
+#         uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+#         with:
+#           user: __token__
+#           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,6 +153,19 @@ sources = ["src/chonkie/chunker/c_extensions/merge.pyx"]
 [tool.setuptools.dynamic]
 version = {attr = "chonkie.__version__"}
 
+[tool.cibuildwheel]
+build = "cp39-* cp310-* cp311-* cp312-* cp313-*"
+skip = "*-win32 *-manylinux_i686"
+
+[tool.cibuildwheel.linux]
+before-all = "yum install -y gcc"
+
+[tool.cibuildwheel.macos]
+before-all = "brew install gcc || true"
+
+[tool.cibuildwheel.windows]
+before-all = "choco install visualcpp-build-tools -y || true"
+
 [tool.ruff]
 exclude = ["*.ipynb"]
 lint.select = ["F", "I", "D"]


### PR DESCRIPTION
This pull request introduces a new workflow for building and publishing Python wheels with support for manylinux and C extensions, while deprecating the old workflow for publishing Python packages. It also updates the `pyproject.toml` file to configure `cibuildwheel` for building wheels across multiple platforms and Python versions.

### New workflow for building and publishing wheels:
* Added a new GitHub Actions workflow `.github/workflows/python-publish-wheels.yml` to build wheels using `cibuildwheel`. The workflow supports manylinux, macOS, and Windows environments, and includes steps for building source distributions and uploading artifacts to PyPI.

### Deprecation of old workflow:
* Commented out the old workflow `.github/workflows/python-publish.yml` for publishing Python packages, which lacked support for manylinux and C extensions.

### Configuration updates for `cibuildwheel`:
* Updated `pyproject.toml` to include a `[tool.cibuildwheel]` section for specifying build configurations, including Python versions (`cp39-*` to `cp313-*`) and exclusions (`*-win32`, `*-manylinux_i686`). Also added platform-specific pre-build commands for Linux, macOS, and Windows.