### PR TITLE
Fix: Update the CD script to use `uv` instead in the hopes of finally publishing the `v1.0.9` 

### DIFF
--- a/.github/workflows/python-publish-wheels.yml
+++ b/.github/workflows/python-publish-wheels.yml
@@ -16,20 +16,32 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-13, macos-latest]
+        # Start with just Linux and one macOS to test
+        os: [ubuntu-latest, macos-13]
 
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Set up Python
+        run: uv python install
+
+      - name: Install cibuildwheel
+        run: uv tool install cibuildwheel
+
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.5
+        run: uv tool run cibuildwheel --output-dir wheelhouse
         env:
           CIBW_BUILD: cp39-* cp310-* cp311-* cp312-* cp313-*
-          CIBW_SKIP: "*-win32 *-manylinux_i686"
+          CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux*"
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
+          CIBW_MANYLINUX_AARCH64_IMAGE: manylinux_2_28
 
       - uses: actions/upload-artifact@v4
         with:
-          name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
+          name: cibw-wheels-${{ matrix.os }}
           path: ./wheelhouse/*.whl
 
   build_sdist:
@@ -38,8 +50,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Set up Python
+        run: uv python install
+
       - name: Build sdist
-        run: pipx run build --sdist
+        run: uv build --sdist
 
       - uses: actions/upload-artifact@v4
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,18 +153,6 @@ sources = ["src/chonkie/chunker/c_extensions/merge.pyx"]
 [tool.setuptools.dynamic]
 version = {attr = "chonkie.__version__"}
 
-[tool.cibuildwheel]
-build = "cp39-* cp310-* cp311-* cp312-* cp313-*"
-skip = "*-win32 *-manylinux_i686"
-
-[tool.cibuildwheel.linux]
-before-all = "yum install -y gcc"
-
-[tool.cibuildwheel.macos]
-before-all = "brew install gcc || true"
-
-[tool.cibuildwheel.windows]
-before-all = "choco install visualcpp-build-tools -y || true"
 
 [tool.ruff]
 exclude = ["*.ipynb"]


### PR DESCRIPTION
This pull request updates the Python wheel publishing workflow to streamline the build process by integrating the `uv` tool and adjusting the platform matrix. Additionally, it removes outdated `cibuildwheel` configurations from `pyproject.toml`. Below are the key changes:

### Workflow Updates:
* Limited the operating system matrix in `.github/workflows/python-publish-wheels.yml` to `ubuntu-latest` and `macos-13` for initial testing, removing `windows-latest` and `macos-latest`.
* Replaced `pypa/cibuildwheel` with the `uv` tool for building wheels and source distributions, including new steps to install and set up `uv`. [[1]](diffhunk://#diff-2849a829827cd04b191e7fd46d1fa37c72f70a42743ab7f3f9ea4c5508a1582cL19-R44) [[2]](diffhunk://#diff-2849a829827cd04b191e7fd46d1fa37c72f70a42743ab7f3f9ea4c5508a1582cR53-R60)
* Updated environment variables to skip additional configurations (`*-musllinux*`) and specify `manylinux_2_28` images for building Linux wheels.

### Configuration Cleanup:
* Removed redundant `cibuildwheel` configurations from `pyproject.toml`, including platform-specific `before-all` commands for Linux, macOS, and Windows.