### PR TITLE
Bump up the version to `v1.0.10`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "chonkie"
-version = "1.0.9"
+version = "1.0.10"
 description = "🦛 CHONK your texts with Chonkie ✨ - The no-nonsense chunking library"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/chonkie/__init__.py
+++ b/src/chonkie/__init__.py
@@ -69,7 +69,7 @@ from .utils import (
 )
 
 # This hippo grows with every release 🦛✨~
-__version__ = "1.0.9"
+__version__ = "1.0.10"
 __name__ = "chonkie"
 __author__ = "🦛 Chonkie Inc"
 


### PR DESCRIPTION
This pull request updates the version of the `chonkie` library from `1.0.9` to `1.0.10`. The changes ensure consistency across the project files.

Version updates:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R7): Updated the `version` field from `1.0.9` to `1.0.10`.
* [`src/chonkie/__init__.py`](diffhunk://#diff-44a557df57b150a7b71a0b691e66e501f00f8983cc9c66dee9309aaf738bd408L72-R72): Updated the `__version__` attribute from `1.0.9` to `1.0.10`.