### PR TITLE
Fix license field of pyproject to follow PEP 621

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "1.0.10"
 description = "🦛 CHONK your texts with Chonkie ✨ - The no-nonsense chunking library"
 readme = "README.md"
 requires-python = ">=3.9"
-license = "MIT"
+license = { text = "MIT" }
 keywords = [
     "chunking",
     "rag",


### PR DESCRIPTION
Got the following error when attempting to run the `pip inststall -e ".[dev]"` command:
```
(venv) (base) chandanhegde@Chandans-MacBook-Pro:~/Desktop/Developer/chonkie$ pip install -e ".[dev]"
Obtaining file:///Users/chandanhegde/Desktop/Developer/chonkie
  Installing build dependencies ... done
  Checking if build backend supports build_editable ... done
  Getting requirements to build editable ... error
  error: subprocess-exited-with-error
  
  × Getting requirements to build editable did not run successfully.
  │ exit code: 1
  ╰─> [95 lines of output]
      Compiling src/chonkie/chunker/c_extensions/split.pyx because it depends on /private/var/folders/x7/ts3hb0pn59zc25x0hwyk7zx00000gn/T/pip-build-env-6e8asw34/overlay/lib/python3.8/site-packages/Cython/Includes/cpython/type.pxd.
      Compiling src/chonkie/chunker/c_extensions/merge.pyx because it depends on /private/var/folders/x7/ts3hb0pn59zc25x0hwyk7zx00000gn/T/pip-build-env-6e8asw34/overlay/lib/python3.8/site-packages/Cython/Includes/libc/stdlib.pxd.
      [1/2] Cythonizing src/chonkie/chunker/c_extensions/merge.pyx
      [2/2] Cythonizing src/chonkie/chunker/c_extensions/split.pyx
      configuration error: `project.license` must be valid exactly by one definition (2 matches found):
      
          - keys:
              'file': {type: string}
            required: ['file']
          - keys:
              'text': {type: string}
            required: ['text']
      
      DESCRIPTION:
          `Project license <https://peps.python.org/pep-0621/#license>`_.
      
      GIVEN VALUE:
          "MIT"
      
      OFFENDING RULE: 'oneOf'
      
      DEFINITION:
          {
              "oneOf": [
                  {
                      "properties": {
                          "file": {
                              "type": "string",
                              "$$description": [
                                  "Relative path to the file (UTF-8) which contains the license for the",
                                  "project."
                              ]
                          }
                      },
                      "required": [
                          "file"
                      ]
                  },
                  {
                      "properties": {
                          "text": {
                              "type": "string",
                              "$$description": [
                                  "The license of the project whose meaning is that of the",
                                  "`License field from the core metadata",
                                  "<https://packaging.python.org/specifications/core-metadata/#license>`_."
                              ]
                          }
                      },
                      "required": [
                          "text"
                      ]
                  }
              ]
          }
```
This change was able to fix it. It seems like this PEP: https://peps.python.org/pep-0621/#license, expects the license field to be a "Table" (JSON object).