### PR TITLE
Fix: return_type is removed for returning only `chunks` to simplify mypy static typing

### DIFF
--- a/cookbook/examples/pgvector_handshake_with_recursive_chunking.py
+++ b/cookbook/examples/pgvector_handshake_with_recursive_chunking.py
@@ -25,14 +25,13 @@ Date: 2025
 
 """
 
+import importlib.util
 import os
 import sys
 import time
 from typing import Dict, Union
 
-try:
-    import vecs
-except ImportError:
+if importlib.util.find_spec("vecs") is None:
     print("❌ Required dependencies not found!")
     print("Install with: pip install 'chonkie[pgvector]'")
     sys.exit(1)

--- a/src/chonkie/chunker/base.py
+++ b/src/chonkie/chunker/base.py
@@ -32,7 +32,7 @@ class BaseChunker(ABC):
 
     def __call__(
         self, text: Union[str, Sequence[str]], show_progress: bool = True
-    ) -> Union[Sequence[Chunk], Sequence[Sequence[Chunk]], Sequence[str], Sequence[Sequence[str]]]:
+    ) -> Union[Sequence[Chunk], Sequence[Sequence[Chunk]]]:
         """Call the chunker with the given arguments.
 
         Args:
@@ -64,7 +64,7 @@ class BaseChunker(ABC):
 
     def _sequential_batch_processing(
         self, texts: Sequence[str], show_progress: bool = True
-    ) -> Union[Sequence[Sequence[Chunk]], Sequence[Sequence[str]]]:
+    ) -> Sequence[Sequence[Chunk]]:
         """Process a batch of texts sequentially."""
         results = [
             self.chunk(t)
@@ -77,11 +77,11 @@ class BaseChunker(ABC):
                 ascii=" o",
             )
         ]
-        return results  # type: ignore[return-value]
+        return results
 
     def _parallel_batch_processing(
         self, texts: Sequence[str], show_progress: bool = True
-    ) -> Union[Sequence[Sequence[Chunk]], Sequence[Sequence[str]]]:
+    ) -> Sequence[Sequence[Chunk]]:
         """Process a batch of texts using multiprocessing."""
         num_workers = self._get_optimal_worker_count()
         total = len(texts)
@@ -100,24 +100,24 @@ class BaseChunker(ABC):
                 for result in pool.imap(self.chunk, texts, chunksize=chunk_size):
                     results.append(result)
                     progress_bar.update()
-            return results  # type: ignore[return-value]
+            return results
 
     @abstractmethod
-    def chunk(self, text: str) -> Union[Sequence[Chunk], Sequence[str]]:
+    def chunk(self, text: str) -> Sequence[Chunk]:
         """Chunk the given text.
 
         Args:
             text (str): The text to chunk.
 
         Returns:
-            Union[Sequence[Chunk], Sequence[str]]: A list of Chunks or a list of strings.
+            Sequence[Chunk]: A list of Chunks.
 
         """
         pass
 
     def chunk_batch(
         self, texts: Sequence[str], show_progress: bool = True
-    ) -> Union[Sequence[Sequence[Chunk]], Sequence[Sequence[str]]]:
+    ) -> Sequence[Sequence[Chunk]]:
         """Chunk a batch of texts.
 
         Args:
@@ -125,7 +125,7 @@ class BaseChunker(ABC):
             show_progress (bool): Whether to show progress.
 
         Returns:
-            Union[Sequence[Sequence[Chunk]], Sequence[Sequence[str]]]: A list of lists of Chunks or a list of lists of strings.
+            Sequence[Sequence[Chunk]]: A list of lists of Chunks.
 
         """
         # simple handles of empty and single text cases

--- a/src/chonkie/chunker/code.py
+++ b/src/chonkie/chunker/code.py
@@ -32,7 +32,6 @@ class CodeChunker(BaseChunker):
         chunk_size: The size of the chunks to create.
         language: The language of the code to parse. Accepts any of the languages supported by tree-sitter-language-pack.
         include_nodes: Whether to include the nodes in the returned chunks.
-        return_type: The type of the return value.
 
     """
 
@@ -40,8 +39,7 @@ class CodeChunker(BaseChunker):
                  tokenizer_or_token_counter: Union[str, List, Any] = "character",
                  chunk_size: int = 2048,
                  language: Union[Literal["auto"], Any] = "auto",
-                 include_nodes: bool = False,
-                 return_type: Literal["chunks", "texts"] = "chunks") -> None:
+                 include_nodes: bool = False) -> None:
         """Initialize a CodeChunker object.
         
         Args:
@@ -49,7 +47,6 @@ class CodeChunker(BaseChunker):
             chunk_size: The size of the chunks to create.
             language: The language of the code to parse. Accepts any of the languages supported by tree-sitter-language-pack.
             include_nodes: Whether to include the nodes in the returned chunks.
-            return_type: The type of the return value.
 
         Raises:
             ImportError: If tree-sitter and tree-sitter-language-pack are not installed.
@@ -62,7 +59,6 @@ class CodeChunker(BaseChunker):
         # Initialize all the values
         self.tokenizer = Tokenizer(tokenizer_or_token_counter)
         self.chunk_size = chunk_size
-        self.return_type = return_type
         self.include_nodes = include_nodes
 
         # TODO: Figure out a way to check if the language is supported by tree-sitter-language-pack
@@ -318,7 +314,7 @@ class CodeChunker(BaseChunker):
             current_index += len(text)
         return chunks
         
-    def chunk(self, text: str) -> Union[List[CodeChunk], List[str]]:
+    def chunk(self, text: str) -> List[CodeChunk]:
         """Recursively chunks the code based on context from tree-sitter."""
         if not text.strip(): # Handle empty or whitespace-only input
             return []
@@ -345,15 +341,11 @@ class CodeChunker(BaseChunker):
                 del tree, root_node
                 node_groups = []
 
-        if self.return_type == "texts":
-            return texts
-        else:
-            chunks = self._create_chunks(texts, token_counts, node_groups)
-            return chunks 
+        chunks = self._create_chunks(texts, token_counts, node_groups)
+        return chunks 
         
     def __repr__(self) -> str:
         """Return the string representation of the CodeChunker."""
         return (f"CodeChunker(tokenizer_or_token_counter={self.tokenizer},"
                 f"chunk_size={self.chunk_size},"
-                f"language={self.language},"
-                f"return_type={self.return_type})")
+                f"language={self.language})")

--- a/src/chonkie/chunker/late.py
+++ b/src/chonkie/chunker/late.py
@@ -72,7 +72,6 @@ class LateChunker(RecursiveChunker):
             chunk_size=chunk_size,
             rules=rules,
             min_characters_per_chunk=min_characters_per_chunk,
-            return_type="chunks",
         )
 
         # Disable multiprocessing for this chunker
@@ -139,7 +138,7 @@ class LateChunker(RecursiveChunker):
         token_embeddings = self.embedding_model.embed_as_tokens(text)
 
         # Get the token_counts for all the chunks
-        # Note: LateChunker always uses return_type="chunks", so chunks are always RecursiveChunk objects
+        # Note: LateChunker always returns chunks, so chunks are always RecursiveChunk objects
         token_counts = [c.token_count for c in chunks]  # type: ignore[union-attr]
 
         # Validate the token_counts with the actual count
@@ -167,7 +166,7 @@ class LateChunker(RecursiveChunker):
         # Wrap it all up in LateChunks
         result = []
         for chunk, token_count, embedding in zip(chunks, token_counts, late_embds):
-            # Note: LateChunker always uses return_type="chunks", so chunk is always a RecursiveChunk
+            # Note: LateChunker always returns chunks, so chunk is always a RecursiveChunk
             result.append(
                 LateChunk(
                     text=chunk.text,  # type: ignore[attr-defined]

--- a/src/chonkie/chunker/neural.py
+++ b/src/chonkie/chunker/neural.py
@@ -6,7 +6,7 @@ It trains an encoder style model on the task of token-classification (think: NER
 """
 
 import importlib.util as importutil
-from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from chonkie.types import Chunk
 
@@ -46,7 +46,6 @@ class NeuralChunker(BaseChunker):
     model: The model to use for the chunker.
     device: The device to use for the chunker.
     min_characters_per_chunk: The minimum number of characters per chunk.
-    return_type: The type of return value.
 
   """
 
@@ -69,8 +68,7 @@ class NeuralChunker(BaseChunker):
                tokenizer: Optional[Union[str, Any]] = None,
                device_map: str = "auto", 
                min_characters_per_chunk: int = 10, 
-               stride: Optional[int] = None,
-               return_type: Literal["chunks", "texts"] = "chunks") -> None:
+               stride: Optional[int] = None) -> None:
     """Initialize the NeuralChunker object.
     
     Args:
@@ -79,7 +77,6 @@ class NeuralChunker(BaseChunker):
       device_map: The device to use for the chunker.
       min_characters_per_chunk: The minimum number of characters per chunk.
       stride: The stride to use for the chunker.
-      return_type: The type of return value.
 
     """
     # Lazily load the dependencies
@@ -123,7 +120,6 @@ class NeuralChunker(BaseChunker):
 
     # Set the attributes
     self.min_characters_per_chunk = min_characters_per_chunk
-    self.return_type = return_type
 
     # Initialize the pipeline
     try:
@@ -204,14 +200,14 @@ class NeuralChunker(BaseChunker):
       current_index += len(split)
     return chunks
 
-  def chunk(self, text: str) -> Union[List[Chunk], List[str]]:
+  def chunk(self, text: str) -> List[Chunk]:
     """Chunk the text into a list of chunks.
     
     Args:
       text: The text to chunk.
 
     Returns:
-      A list of chunks or a list of strings.
+      A list of chunks.
 
     """
     # Get the spans
@@ -224,16 +220,12 @@ class NeuralChunker(BaseChunker):
     # Get the splits from the merged spans
     splits = self._get_splits(merged_spans, text)
 
-    # Return the chunks or the texts
-    if self.return_type == "texts":
-      return splits
-    else:
-      chunks = self._get_chunks_from_splits(splits)
-      return chunks
+    # Return the chunks
+    chunks = self._get_chunks_from_splits(splits)
+    return chunks
 
   def __repr__(self) -> str:
     """Return the string representation of the object."""
     return (f"NeuralChunker(model={self.model},"
             f"tokenizer={self.tokenizer}, "
-            f"min_characters_per_chunk={self.min_characters_per_chunk}, "
-            f"return_type={self.return_type})")
+            f"min_characters_per_chunk={self.min_characters_per_chunk})")

--- a/src/chonkie/chunker/sdpm.py
+++ b/src/chonkie/chunker/sdpm.py
@@ -30,7 +30,6 @@ class SDPMChunker(SemanticChunker):
         delim: The delimiters to use.
         include_delim: Whether to include delimiters in chunks.
         skip_window: The skip window to use.
-        return_type: The return type to use.
         **kwargs: Additional keyword arguments.
 
     """
@@ -49,7 +48,6 @@ class SDPMChunker(SemanticChunker):
         delim: Union[str, List[str]] = [". ", "! ", "? ", "\n"],
         include_delim: Optional[Literal["prev", "next"]] = "prev",
         skip_window: int = 1,
-        return_type: Literal["chunks", "texts"] = "chunks",
         **kwargs: Dict[str, Any],
     ) -> None:  # type: ignore
         """Initialize the SDPMChunker.
@@ -67,7 +65,6 @@ class SDPMChunker(SemanticChunker):
             delim: The delimiters to use.
             include_delim: Whether to include delimiters.
             skip_window: The skip window to use.
-            return_type: The return type to use.
             **kwargs: Additional keyword arguments.
 
         """
@@ -83,7 +80,6 @@ class SDPMChunker(SemanticChunker):
             threshold_step=threshold_step,
             delim=delim,
             include_delim=include_delim,
-            return_type=return_type,
             **kwargs,
         )
 
@@ -108,7 +104,6 @@ class SDPMChunker(SemanticChunker):
                     min_characters_per_sentence: int = 12,
                     threshold_step: float = 0.01,
                     skip_window: int = 1,
-                    return_type: Literal["chunks", "texts"] = "chunks",
                     **kwargs: Dict[str, Any]) -> "SDPMChunker":  # type: ignore
         """Create a SDPMChunker from a recipe.
 
@@ -126,7 +121,6 @@ class SDPMChunker(SemanticChunker):
             min_characters_per_sentence: The minimum number of characters per sentence to use.
             threshold_step: The threshold step to use.
             skip_window: The skip window to use.
-            return_type: The return type to use.
             **kwargs: Additional keyword arguments.
 
         Returns:
@@ -152,7 +146,6 @@ class SDPMChunker(SemanticChunker):
             delim=recipe["recipe"]["delimiters"],
             include_delim=recipe["recipe"]["include_delim"],
             skip_window=skip_window,
-            return_type=return_type,
             **kwargs,
         )
 
@@ -262,6 +255,5 @@ class SDPMChunker(SemanticChunker):
             f"threshold_step={self.threshold_step}, "
             f"delim={self.delim}, "
             f"include_delim={self.include_delim}, "
-            f"skip_window={self.skip_window}, "
-            f"return_type={self.return_type})"
+            f"skip_window={self.skip_window})"
         )

--- a/src/chonkie/chunker/semantic.py
+++ b/src/chonkie/chunker/semantic.py
@@ -35,7 +35,6 @@ class SemanticChunker(BaseChunker):
         threshold_step: Step size for similarity threshold calculation
         delim: Delimiters to split sentences on
         include_delim: Whether to include the delimiters in the sentences
-        return_type: Whether to return chunks or texts
 
     Raises:
         ValueError: If parameters are invalid
@@ -54,8 +53,7 @@ class SemanticChunker(BaseChunker):
         min_characters_per_sentence: int = 12,
         threshold_step: float = 0.01,
         delim: Union[str, List[str]] = [". ", "! ", "? ", "\n"],
-        include_delim: Union[Literal["prev", "next"], None] = "prev",
-        return_type: Literal["chunks", "texts"] = "chunks",
+        include_delim: Optional[Literal["prev", "next"]] = "prev",
         **kwargs: Dict[str, Any],
     ) -> None:  # type: ignore
         """Initialize the SemanticChunker.
@@ -74,7 +72,6 @@ class SemanticChunker(BaseChunker):
             threshold_step: Step size for similarity threshold calculation
             delim: Delimiters to split sentences on
             include_delim: Whether to include the delimiters in the sentences
-            return_type: Whether to return chunks or texts
             **kwargs: Additional keyword arguments
 
         Raises:
@@ -104,8 +101,6 @@ class SemanticChunker(BaseChunker):
             raise ValueError("threshold (float) must be between 0 and 1")
         elif type(threshold) == int and (threshold < 1 or threshold > 100):
             raise ValueError("threshold (int) must be between 1 and 100")
-        if return_type not in ["chunks", "texts"]:
-            raise ValueError("Invalid return_type. Must be either 'chunks' or 'texts'.")
 
         # Lazy import dependencies to avoid importing them when not needed
         self._import_dependencies()
@@ -121,7 +116,6 @@ class SemanticChunker(BaseChunker):
         self.delim = delim
         self.include_delim = include_delim
         self.sep = "✄"
-        self.return_type = return_type
 
         # Initialize with type annotations
         self.similarity_threshold: Optional[float]
@@ -176,7 +170,6 @@ class SemanticChunker(BaseChunker):
                     min_chunk_size: int = 2,
                     min_characters_per_sentence: int = 12,
                     threshold_step: float = 0.01,
-                    return_type: Literal["chunks", "texts"] = "chunks",
                     **kwargs: Dict[str, Any]    
                     ) -> "SemanticChunker":
         """Create a SemanticChunker from a recipe.
@@ -194,7 +187,6 @@ class SemanticChunker(BaseChunker):
             min_chunk_size: The minimum number of tokens per chunk.
             min_characters_per_sentence: The minimum number of characters per sentence.
             threshold_step: The step size for similarity threshold calculation.
-            return_type: Whether to return chunks or texts.
             **kwargs: Additional keyword arguments.
 
         Returns:
@@ -219,7 +211,6 @@ class SemanticChunker(BaseChunker):
             threshold_step=threshold_step,
             delim=recipe["recipe"]["delimiters"],
             include_delim=recipe["recipe"]["include_delim"],
-            return_type=return_type,
             **kwargs,
         ) 
 
@@ -606,29 +597,25 @@ class SemanticChunker(BaseChunker):
         else:
             return self._group_sentences_window(sentences)
 
-    def _create_chunk(self, sentences: List[SemanticSentence]) -> Union[SemanticChunk, str]:
+    def _create_chunk(self, sentences: List[SemanticSentence]) -> SemanticChunk:
         """Create a chunk from a list of sentences."""
         if not sentences:
             raise ValueError("Cannot create chunk from empty sentence list")
-        if self.return_type == "chunks":
-            # Compute chunk text and token count from sentences
-            text = "".join(sent.text for sent in sentences)
-            token_count = sum(sent.token_count for sent in sentences)
-            return SemanticChunk(
-                text=text,
-                start_index=sentences[0].start_index,
-                end_index=sentences[-1].end_index,
-                token_count=token_count,
-                sentences=sentences,
-            )
-        elif self.return_type == "texts":
-            return "".join(sent.text for sent in sentences)
-        else:
-            raise ValueError("Invalid return_type. Must be either 'chunks' or 'texts'.")
+        
+        # Compute chunk text and token count from sentences
+        text = "".join(sent.text for sent in sentences)
+        token_count = sum(sent.token_count for sent in sentences)
+        return SemanticChunk(
+            text=text,
+            start_index=sentences[0].start_index,
+            end_index=sentences[-1].end_index,
+            token_count=token_count,
+            sentences=sentences,
+        )
 
     def _split_chunks(
         self, sentence_groups: List[List[SemanticSentence]]
-    ) -> Union[List[SemanticChunk], List[str]]:
+    ) -> List[SemanticChunk]:
         """Split sentence groups into chunks that respect chunk_size.
 
         Args:
@@ -638,7 +625,7 @@ class SemanticChunker(BaseChunker):
             List of SemanticChunk objects
 
         """
-        chunks: List[Union[SemanticChunk, str]] = []
+        chunks: List[SemanticChunk] = []
 
         for group in sentence_groups:
             current_chunk_sentences: List[SemanticSentence] = []
@@ -668,13 +655,9 @@ class SemanticChunker(BaseChunker):
             if current_chunk_sentences:
                 chunks.append(self._create_chunk(current_chunk_sentences))
 
-        # Type narrowing based on return_type
-        if self.return_type == "chunks":
-            return [chunk for chunk in chunks if isinstance(chunk, SemanticChunk)]
-        else:
-            return [chunk for chunk in chunks if isinstance(chunk, str)]
+        return chunks
 
-    def chunk(self, text: str) -> Union[Sequence[SemanticChunk], Sequence[str]]:
+    def chunk(self, text: str) -> Sequence[SemanticChunk]:
         """Split text into semantically coherent chunks using two-pass approach.
 
         First groups sentences by semantic similarity, then splits groups to respect
@@ -694,10 +677,7 @@ class SemanticChunker(BaseChunker):
         sentences = self._prepare_sentences(text)
         if len(sentences) <= self.min_sentences:
             chunk_result = self._create_chunk(sentences)
-            if self.return_type == "chunks":
-                return [chunk_result]  # type: ignore[return-value]
-            else:
-                return [chunk_result]  # type: ignore[return-value]
+            return [chunk_result]
 
         # Calculate similarity threshold
         self.similarity_threshold = self._calculate_similarity_threshold(sentences)
@@ -733,6 +713,5 @@ class SemanticChunker(BaseChunker):
             f"threshold={self.threshold}, "
             f"similarity_window={self.similarity_window}, "
             f"min_sentences={self.min_sentences}, "
-            f"min_chunk_size={self.min_chunk_size}, "
-            f"return_type={self.return_type})"
+            f"min_chunk_size={self.min_chunk_size})"
         )

--- a/src/chonkie/chunker/slumber.py
+++ b/src/chonkie/chunker/slumber.py
@@ -2,7 +2,7 @@
 
 from bisect import bisect_left
 from itertools import accumulate
-from typing import Any, Callable, List, Literal, Optional, Union
+from typing import Any, Callable, List, Optional, Union
 
 from tqdm import tqdm
 
@@ -63,7 +63,6 @@ class SlumberChunker(BaseChunker):
                  rules: RecursiveRules = RecursiveRules(),
                  candidate_size: int = 128,
                  min_characters_per_chunk: int = 24,
-                 return_type: Literal["chunks", "texts"] = "chunks", 
                  verbose: bool = True):
         """Initialize the SlumberChunker.
 
@@ -74,7 +73,6 @@ class SlumberChunker(BaseChunker):
             rules (RecursiveRules): The rules to use to split the candidate chunks.
             candidate_size (int): The size of the candidate splits that the chunker will consider.
             min_characters_per_chunk (int): The minimum number of characters per chunk.
-            return_type (Literal["chunks", "texts"]): The type of output to return.
             verbose (bool): Whether to print verbose output.
 
         """
@@ -94,7 +92,6 @@ class SlumberChunker(BaseChunker):
         self.candidate_size = candidate_size
         self.rules = rules
         self.min_characters_per_chunk = min_characters_per_chunk
-        self.return_type = return_type
         self.verbose = verbose
 
         # Set the parameters for the defualt prompt template
@@ -318,6 +315,5 @@ class SlumberChunker(BaseChunker):
                 f"tokenizer_or_token_counter={self.tokenizer}, " +
                 f"chunk_size={self.chunk_size}, " +
                 f"candidate_size={self.candidate_size}, " +
-                f"min_characters_per_chunk={self.min_characters_per_chunk}, " +
-                f"return_type={self.return_type})" # type: ignore
+                f"min_characters_per_chunk={self.min_characters_per_chunk})" # type: ignore
             )

--- a/src/chonkie/chunker/token.py
+++ b/src/chonkie/chunker/token.py
@@ -4,7 +4,7 @@ This module provides a TokenChunker class for splitting text into chunks of a sp
 
 """
 
-from typing import Any, Generator, List, Literal, Sequence, Union
+from typing import Any, Generator, List, Sequence, Union
 
 from tqdm import trange
 
@@ -19,7 +19,6 @@ class TokenChunker(BaseChunker):
         tokenizer: The tokenizer instance to use for encoding/decoding
         chunk_size: Maximum number of tokens per chunk
         chunk_overlap: Number of tokens to overlap between chunks
-        return_type: Whether to return chunks or texts
 
     """
 
@@ -28,7 +27,6 @@ class TokenChunker(BaseChunker):
         tokenizer: Union[str, Any] = "character",
         chunk_size: int = 2048,
         chunk_overlap: Union[int, float] = 0,
-        return_type: Literal["chunks", "texts"] = "chunks",
     ) -> None:
         """Initialize the TokenChunker with configuration parameters.
 
@@ -36,7 +34,6 @@ class TokenChunker(BaseChunker):
             tokenizer: The tokenizer instance to use for encoding/decoding
             chunk_size: Maximum number of tokens per chunk
             chunk_overlap: Number of tokens to overlap between chunks
-            return_type: Whether to return chunks or texts
 
         Raises:
             ValueError: If chunk_size <= 0 or chunk_overlap >= chunk_size
@@ -47,11 +44,8 @@ class TokenChunker(BaseChunker):
             raise ValueError("chunk_size must be positive")
         if isinstance(chunk_overlap, int) and chunk_overlap >= chunk_size:
             raise ValueError("chunk_overlap must be less than chunk_size")
-        if return_type not in ["chunks", "texts"]:
-            raise ValueError("return_type must be either 'chunks' or 'texts'")
 
         # Assign the values if they make sense
-        self.return_type = return_type
         self.chunk_size = chunk_size
         self.chunk_overlap = (
             chunk_overlap
@@ -112,7 +106,7 @@ class TokenChunker(BaseChunker):
             if end == len(tokens):
                 break
 
-    def chunk(self, text: str) -> Union[Sequence[Chunk], Sequence[str]]:
+    def chunk(self, text: str) -> Sequence[Chunk]:
         """Split text into overlapping chunks of specified token size.
 
         Args:
@@ -130,21 +124,15 @@ class TokenChunker(BaseChunker):
 
         # Calculate token groups and counts
         token_groups = list(self._token_group_generator(text_tokens))
+        token_counts = [len(toks) for toks in token_groups]
 
-        # if return_type is chunks, we need to decode the token groups into the chunk texts
-        if self.return_type == "chunks":
-            token_counts = [len(toks) for toks in token_groups]
+        # decode the token groups into the chunk texts
+        chunk_texts = self.tokenizer.decode_batch(token_groups)
 
-            # decode the token groups into the chunk texts
-            chunk_texts = self.tokenizer.decode_batch(token_groups)
+        # Create the chunks from the token groups and token counts
+        chunks = self._create_chunks(chunk_texts, token_groups, token_counts)
 
-            # Create the chunks from the token groups and token counts
-            chunks = self._create_chunks(chunk_texts, token_groups, token_counts)
-
-            return chunks
-        # if return_type is texts, we can just return the decoded token groups
-        elif self.return_type == "texts":
-            return self.tokenizer.decode_batch(token_groups)
+        return chunks
 
     def _process_batch(self, texts: List[str]) -> Sequence[Sequence[Chunk]]:
         """Process a batch of texts."""
@@ -160,22 +148,15 @@ class TokenChunker(BaseChunker):
             # get the token groups
             token_groups = list(self._token_group_generator(tokens))
 
-            if self.return_type == "chunks":
-                # get the token counts
-                token_counts = [len(token_group) for token_group in token_groups]
+            # get the token counts
+            token_counts = [len(token_group) for token_group in token_groups]
 
-                # decode the token groups into the chunk texts
-                chunk_texts = self.tokenizer.decode_batch(token_groups)
+            # decode the token groups into the chunk texts
+            chunk_texts = self.tokenizer.decode_batch(token_groups)
 
-                # create the chunks from the token groups and token counts
-                chunks = self._create_chunks(chunk_texts, token_groups, token_counts)
-                result.append(chunks)
-            elif self.return_type == "texts":
-                result.append(self.tokenizer.decode_batch(token_groups))
-            else:
-                raise ValueError(
-                    "Invalid return_type. Must be either 'chunks' or 'texts'."
-                )
+            # create the chunks from the token groups and token counts
+            chunks = self._create_chunks(chunk_texts, token_groups, token_counts)
+            result.append(chunks)
 
         return result
 
@@ -216,7 +197,7 @@ class TokenChunker(BaseChunker):
         text: Union[str, List[str]],
         batch_size: int = 1,
         show_progress_bar: bool = True,
-    ) -> Union[Sequence[Chunk], Sequence[Sequence[Chunk]], Sequence[str], Sequence[Sequence[str]]]:
+    ) -> Union[Sequence[Chunk], Sequence[Sequence[Chunk]]]:
         """Make the TokenChunker callable directly.
 
         Args:
@@ -242,6 +223,5 @@ class TokenChunker(BaseChunker):
         return (
             f"TokenChunker(tokenizer={self.tokenizer}, "
             f"chunk_size={self.chunk_size}, "
-            f"chunk_overlap={self.chunk_overlap}, "
-            f"return_type={self.return_type})"
+            f"chunk_overlap={self.chunk_overlap})"
         )

--- a/src/chonkie/cloud/chunker/token.py
+++ b/src/chonkie/cloud/chunker/token.py
@@ -1,7 +1,7 @@
 """Cloud Token Chunking for Chonkie API."""
 
 import os
-from typing import Dict, List, Literal, Optional, Union, cast
+from typing import Dict, List, Optional, Union, cast
 
 import requests
 

--- a/src/chonkie/cloud/chunker/token.py
+++ b/src/chonkie/cloud/chunker/token.py
@@ -21,7 +21,6 @@ class TokenChunker(CloudChunker):
         tokenizer: str = "gpt2",
         chunk_size: int = 512,
         chunk_overlap: int = 0,
-        return_type: Literal["texts", "chunks"] = "chunks",
         api_key: Optional[str] = None,
     ) -> None:
         """Initialize the Cloud TokenChunker."""
@@ -39,15 +38,10 @@ class TokenChunker(CloudChunker):
         if chunk_overlap < 0:
             raise ValueError("Chunk overlap must be greater than or equal to 0.")
 
-        # Check if return_type is valid
-        if return_type not in ["texts", "chunks"]:
-            raise ValueError("Return type must be either 'texts' or 'chunks'.")
-
         # Assign all the attributes to the instance
         self.tokenizer = tokenizer
         self.chunk_size = chunk_size
         self.chunk_overlap = chunk_overlap
-        self.return_type = return_type
 
         # Check if the API is up right now
         response = requests.get(f"{self.BASE_URL}/")
@@ -66,7 +60,7 @@ class TokenChunker(CloudChunker):
             "tokenizer": self.tokenizer,
             "chunk_size": self.chunk_size,
             "chunk_overlap": self.chunk_overlap,
-            "return_type": self.return_type,
+            "return_type": "chunks",  # Always request chunks to maintain consistency
         }
         # Make the request to the Chonkie API
         response = requests.post(

--- a/tests/chunkers/test_code_chunker.py
+++ b/tests/chunkers/test_code_chunker.py
@@ -54,7 +54,6 @@ def test_code_chunker_initialization() -> None:
     """Test CodeChunker initialization."""
     chunker = CodeChunker(language="python", chunk_size=128)
     assert chunker.chunk_size == 128
-    assert chunker.return_type == "chunks"
     assert chunker.parser is not None
 
 
@@ -104,14 +103,14 @@ def test_code_chunker_indices_python(python_code: str) -> None:
     assert current_index == len(python_code)
 
 
-def test_code_chunker_return_type_texts(python_code: str) -> None:
-    """Test return_type='texts'."""
-    chunker = CodeChunker(language="python", chunk_size=50, return_type="texts")
-    texts = chunker.chunk(python_code)
-    assert isinstance(texts, list)
-    assert len(texts) > 0
-    assert all(isinstance(text, str) for text in texts)
-    reconstructed_text = "".join(texts)
+def test_code_chunker_return_type_chunks(python_code: str) -> None:
+    """Test that chunker returns CodeChunk objects by default."""
+    chunker = CodeChunker(language="python", chunk_size=50)
+    chunks = chunker.chunk(python_code)
+    assert isinstance(chunks, list)
+    assert len(chunks) > 0
+    assert all(isinstance(chunk, CodeChunk) for chunk in chunks)
+    reconstructed_text = "".join(chunk.text for chunk in chunks)
     assert reconstructed_text == python_code
 
 
@@ -121,10 +120,10 @@ def test_code_chunker_empty_input() -> None:
     chunks = chunker.chunk("")
     assert chunks == []
 
-    # Test return_type='texts'
-    chunker = CodeChunker(language="python", return_type="texts")
-    texts = chunker.chunk("")
-    assert texts == []
+    # Test with default chunker (returns chunks)
+    chunker_default = CodeChunker(language="python")
+    chunks_default = chunker_default.chunk("")
+    assert chunks_default == []
 
 
 def test_code_chunker_whitespace_input() -> None:
@@ -133,10 +132,10 @@ def test_code_chunker_whitespace_input() -> None:
     chunks = chunker.chunk("   \n\t\n  ")
     assert chunks == []
 
-    # Test return_type='texts'
-    chunker = CodeChunker(language="python", return_type="texts")
-    texts = chunker.chunk("   \n\t\n  ")
-    assert texts == []
+    # Test with default chunker (returns chunks)
+    chunker_default = CodeChunker(language="python")
+    chunks_default = chunker_default.chunk("   \n\t\n  ")
+    assert chunks_default == []
 
 
 def test_code_chunker_chunking_javascript(js_code: str) -> None:

--- a/tests/chunkers/test_neural_chunker.py
+++ b/tests/chunkers/test_neural_chunker.py
@@ -59,11 +59,10 @@ class TestNeuralChunkerInitialization:
             chunker = NeuralChunker(
                 model="mirth/chonky_distilbert_base_uncased_1",
                 min_characters_per_chunk=20,
-                stride=128,
-                return_type="texts"
+                stride=128
             )
             assert chunker.min_characters_per_chunk == 20
-            assert chunker.return_type == "texts"
+            assert chunker.return_type == "chunks"
         except Exception:
             pytest.skip("transformers not available or model not accessible")
 
@@ -221,17 +220,16 @@ class TestNeuralChunkerChunking:
         reconstructed = "".join(chunk.text for chunk in result)
         assert reconstructed == sample_text
 
-    def test_chunk_returns_texts(self, neural_chunker, sample_text):
-        """Test chunking returns text strings."""
-        neural_chunker.return_type = "texts"
+    def test_chunk_returns_chunks(self, neural_chunker, sample_text):
+        """Test chunking returns chunk objects by default."""
         result = neural_chunker.chunk(sample_text)
         
         assert isinstance(result, list)
         assert len(result) > 0
-        assert all(isinstance(text, str) for text in result)
+        assert all(hasattr(chunk, 'text') for chunk in result)
         
-        # Verify texts reconstruct the original text
-        reconstructed = "".join(result)
+        # Verify chunk texts reconstruct the original text
+        reconstructed = "".join(chunk.text for chunk in result)
         assert reconstructed == sample_text
 
     def test_chunk_consistency(self, neural_chunker, sample_text):
@@ -325,19 +323,17 @@ class TestNeuralChunkerRepresentation:
         
         assert "NeuralChunker" in repr_str
         assert "min_characters_per_chunk" in repr_str
-        assert "return_type" in repr_str
 
     def test_repr_with_custom_params(self):
         """Test __repr__ with custom parameters."""
         try:
             chunker = NeuralChunker(
-                min_characters_per_chunk=20, 
-                return_type="texts"
+                min_characters_per_chunk=20
             )
             repr_str = repr(chunker)
             
             assert "min_characters_per_chunk=20" in repr_str
-            assert "return_type=texts" in repr_str
+            assert "return_type=chunks" in repr_str
         except Exception:
             pytest.skip("transformers not available or model not accessible")
 

--- a/tests/chunkers/test_neural_chunker.py
+++ b/tests/chunkers/test_neural_chunker.py
@@ -3,7 +3,6 @@
 import pytest
 
 from chonkie import NeuralChunker
-from chonkie.types.base import Chunk
 
 
 @pytest.fixture
@@ -206,19 +205,6 @@ class TestNeuralChunkerInternalMethods:
 
 class TestNeuralChunkerChunking:
     """Test the main chunking functionality."""
-
-    def test_chunk_returns_chunks(self, neural_chunker, sample_text):
-        """Test chunking returns Chunk objects."""
-        neural_chunker.return_type = "chunks"
-        result = neural_chunker.chunk(sample_text)
-        
-        assert isinstance(result, list)
-        assert len(result) > 0
-        assert all(isinstance(chunk, Chunk) for chunk in result)
-        
-        # Verify chunks reconstruct the original text
-        reconstructed = "".join(chunk.text for chunk in result)
-        assert reconstructed == sample_text
 
     def test_chunk_returns_chunks(self, neural_chunker, sample_text):
         """Test chunking returns chunk objects by default."""

--- a/tests/chunkers/test_recursive_chunker.py
+++ b/tests/chunkers/test_recursive_chunker.py
@@ -424,7 +424,6 @@ def test_recursive_chunker_from_recipe_default() -> None:
     assert chunker.rules is not None and isinstance(chunker.rules, RecursiveRules)
     assert chunker.chunk_size == 2048
     assert chunker.min_characters_per_chunk == 24
-    assert chunker.return_type == "chunks"
 
 def test_recursive_chunker_from_recipe_custom_params() -> None:
     """Test that RecursiveChunker.from_recipe works with custom parameters."""
@@ -432,15 +431,13 @@ def test_recursive_chunker_from_recipe_custom_params() -> None:
         name="default",
         lang="en",
         chunk_size=256,
-        min_characters_per_chunk=32,
-        return_type="texts"
+        min_characters_per_chunk=32
     )
 
     assert chunker is not None
     assert chunker.rules is not None and isinstance(chunker.rules, RecursiveRules)
     assert chunker.chunk_size == 256
     assert chunker.min_characters_per_chunk == 32
-    assert chunker.return_type == "texts"
 
 def test_recursive_chunker_from_recipe_custom_lang() -> None:
     """Test that RecursiveChunker.from_recipe works with custom language."""
@@ -449,15 +446,13 @@ def test_recursive_chunker_from_recipe_custom_lang() -> None:
         lang="en",
         tokenizer_or_token_counter="character",
         chunk_size=256,
-        min_characters_per_chunk=32,
-        return_type="texts"
+        min_characters_per_chunk=32
     )
     
     assert chunker is not None
     assert chunker.rules is not None and isinstance(chunker.rules, RecursiveRules)
     assert chunker.chunk_size == 256
     assert chunker.min_characters_per_chunk == 32
-    assert chunker.return_type == "texts"
 
 def test_recursive_chunker_from_recipe_nonexistent() -> None:
     """Test that RecursiveChunker.from_recipe raises an error for nonexistent recipes."""

--- a/tests/chunkers/test_sdpm_chunker.py
+++ b/tests/chunkers/test_sdpm_chunker.py
@@ -444,22 +444,18 @@ class TestSDPMChunkerParameterVariations:
             assert chunker.min_chunk_size == min_size
 
     def test_return_type_parameter(self, embedding_model, sample_text):
-        """Test with different return types."""
-        # Test chunks return type
-        chunker_chunks = SDPMChunker(
-            embedding_model=embedding_model,
-            return_type="chunks"
+        """Test that chunker returns SemanticChunk objects by default."""
+        # Test default return type (chunks)
+        chunker = SDPMChunker(
+            embedding_model=embedding_model
         )
-        result_chunks = chunker_chunks.chunk(sample_text)
-        assert all(isinstance(item, SemanticChunk) for item in result_chunks)
+        result = chunker.chunk(sample_text)
+        assert all(isinstance(item, SemanticChunk) for item in result)
         
-        # Test texts return type
-        chunker_texts = SDPMChunker(
-            embedding_model=embedding_model,
-            return_type="texts"
-        )
-        result_texts = chunker_texts.chunk(sample_text)
-        assert all(isinstance(item, str) for item in result_texts)
+        # Test that text content is accessible via .text property
+        for chunk in result:
+            assert isinstance(chunk.text, str)
+            assert len(chunk.text) > 0
 
 
 class TestSDPMChunkerRecipeFeature:

--- a/tests/chunkers/test_semantic_chunker.py
+++ b/tests/chunkers/test_semantic_chunker.py
@@ -230,8 +230,7 @@ def test_semantic_chunker_repr(embedding_model: BaseEmbeddings) -> None:
         f"threshold={chunker.threshold}, "
         f"similarity_window={chunker.similarity_window}, "
         f"min_sentences={chunker.min_sentences}, "
-        f"min_chunk_size={chunker.min_chunk_size}, "
-        f"return_type={chunker.return_type})"
+        f"min_chunk_size={chunker.min_chunk_size})"
     )
     assert repr(chunker) == expected
 
@@ -349,17 +348,16 @@ def test_semantic_chunker_reconstruction_batch(embedding_model: BaseEmbeddings, 
 
 
 def test_semantic_chunker_return_type(embedding_model: BaseEmbeddings, sample_text: str) -> None:
-    """Test that SemanticChunker's return type is correctly set."""
+    """Test that SemanticChunker returns SemanticChunk objects by default."""
     chunker = SemanticChunker(
         embedding_model=embedding_model,
         chunk_size=512,
         threshold=0.5,
-        return_type="texts",
     )
     chunks = chunker.chunk(sample_text)
     tokenizer = embedding_model.get_tokenizer_or_token_counter()
-    assert all([type(chunk) is str for chunk in chunks])
-    assert all([len(tokenizer.encode(chunk)) <= 512 for chunk in chunks])
+    assert all([hasattr(chunk, 'text') for chunk in chunks])
+    assert all([len(tokenizer.encode(chunk.text)) <= 512 for chunk in chunks])
 
 
 def test_semantic_chunker_from_recipe_default() -> None:
@@ -378,7 +376,6 @@ def test_semantic_chunker_from_recipe_custom_params(embedding_model: BaseEmbeddi
         embedding_model=embedding_model,
         chunk_size=256,
         threshold=0.9,
-        return_type="texts",
     )
 
     assert chunker is not None
@@ -386,7 +383,6 @@ def test_semantic_chunker_from_recipe_custom_params(embedding_model: BaseEmbeddi
     assert chunker.include_delim == "prev"
     assert chunker.chunk_size == 256
     assert chunker.threshold == 0.9
-    assert chunker.return_type == "texts"
 
 def test_semantic_chunker_from_recipe_nonexistent() -> None:
     """Test that SemanticChunker.from_recipe raises an error if the recipe does not exist."""
@@ -475,10 +471,6 @@ class TestSemanticChunkerParameterValidation:
         with pytest.raises(ValueError, match="delim must be a string or list of strings"):
             SemanticChunker(embedding_model=embedding_model, delim=123)
 
-    def test_invalid_return_type(self, embedding_model: BaseEmbeddings) -> None:
-        """Test that SemanticChunker raises error for invalid return_type."""
-        with pytest.raises(ValueError, match="Invalid return_type. Must be either 'chunks' or 'texts'."):
-            SemanticChunker(embedding_model=embedding_model, return_type="invalid")
 
     def test_invalid_embedding_model_type(self) -> None:
         """Test that SemanticChunker raises error for invalid embedding model type."""
@@ -698,27 +690,17 @@ class TestSemanticChunkerInternalMethods:
         with pytest.raises(ValueError, match="Cannot create chunk from empty sentence list"):
             chunker._create_chunk([])
 
-    def test_create_chunk_with_texts_return_type(self, embedding_model: BaseEmbeddings) -> None:
-        """Test _create_chunk with return_type='texts'."""
+    def test_create_chunk_with_default_return_type(self, embedding_model: BaseEmbeddings) -> None:
+        """Test _create_chunk with default return_type (chunks)."""
         chunker = SemanticChunker(
-            embedding_model=embedding_model, 
-            return_type="texts"
+            embedding_model=embedding_model
         )
         sentences = chunker._prepare_sentences("This is a test sentence.")
         
         if sentences:
             result = chunker._create_chunk(sentences)
-            assert isinstance(result, str)
+            assert hasattr(result, 'text')
 
-    def test_create_chunk_invalid_return_type(self, embedding_model: BaseEmbeddings) -> None:
-        """Test _create_chunk with invalid return_type."""
-        chunker = SemanticChunker(embedding_model=embedding_model)
-        chunker.return_type = "invalid"  # Force invalid return type
-        sentences = chunker._prepare_sentences("This is a test sentence.")
-        
-        if sentences:
-            with pytest.raises(ValueError, match="Invalid return_type. Must be either 'chunks' or 'texts'."):
-                chunker._create_chunk(sentences)
 
 
 class TestSemanticChunkerThresholdCalculation:

--- a/tests/chunkers/test_sentence_chunker.py
+++ b/tests/chunkers/test_sentence_chunker.py
@@ -66,7 +66,6 @@ def test_sentence_chunker_initialization(tokenizer: Tokenizer) -> None:
     assert chunker.approximate == False
     assert chunker.delim == [".", "!", "?", "\n"]
     assert chunker.include_delim == "prev"
-    assert chunker.return_type == "chunks"
 
 
 def test_sentence_chunker_chunking(tokenizer: Tokenizer, sample_text: str) -> None:
@@ -145,8 +144,7 @@ def test_sentence_chunker_repr(tokenizer: Tokenizer) -> None:
         f"min_characters_per_sentence={chunker.min_characters_per_sentence}, "
         f"approximate={chunker.approximate}, "
         f"delim={chunker.delim}, "
-        f"include_delim={chunker.include_delim}, "
-        f"return_type={chunker.return_type})"
+        f"include_delim={chunker.include_delim})"
     )
 
 
@@ -242,16 +240,15 @@ def test_sentence_chunker_token_counts(tokenizer: Tokenizer, sample_text: str) -
 
 
 def test_sentence_chunker_return_type(tokenizer: Tokenizer, sample_text: str) -> None:
-    """Test that SentenceChunker's return type is correctly set."""
+    """Test that SentenceChunker returns Chunk objects by default."""
     chunker = SentenceChunker(
         tokenizer_or_token_counter=tokenizer,
         chunk_size=512,
         chunk_overlap=128,
-        return_type="texts",
     )
     chunks = chunker.chunk(sample_text)
-    assert all([type(chunk) is str for chunk in chunks])
-    assert all([len(tokenizer.encode(chunk)) <= 512 for chunk in chunks])
+    assert all([hasattr(chunk, 'text') for chunk in chunks])
+    assert all([len(tokenizer.encode(chunk.text)) <= 512 for chunk in chunks])
 
 
 def test_sentence_chunker_min_sentences_per_chunk(tokenizer: Tokenizer, sample_text: str) -> None:
@@ -296,14 +293,12 @@ def test_sentence_chunker_from_recipe_custom_params() -> None:
         name="default",
         lang="en",
         chunk_size=256,
-        min_characters_per_sentence=32,
-        return_type="texts"
+        min_characters_per_sentence=32
     )
 
     assert chunker is not None
     assert chunker.chunk_size == 256
     assert chunker.min_characters_per_sentence == 32
-    assert chunker.return_type == "texts"
     assert chunker.delim == [". ", "! ", "? ", "\n"]
     assert chunker.include_delim == "prev"
 
@@ -315,13 +310,11 @@ def test_sentence_chunker_from_recipe_custom_lang() -> None:
             lang="hi",
             chunk_size=512,
             min_characters_per_sentence=12,
-            return_type="chunks",
         )
 
         assert chunker is not None
         assert chunker.chunk_size == 512
         assert chunker.min_characters_per_sentence == 12
-        assert chunker.return_type == "chunks"
         assert chunker.delim is not None
         assert chunker.include_delim is not None
     except (OSError, ValueError, ConnectionError, Exception) as e:

--- a/tests/chunkers/test_slumber_chunker.py
+++ b/tests/chunkers/test_slumber_chunker.py
@@ -93,7 +93,6 @@ class TestSlumberChunkerInitialization:
         assert chunker.chunk_size == 2048
         assert chunker.candidate_size == 128
         assert chunker.min_characters_per_chunk == 24
-        assert chunker.return_type == "chunks"
         assert chunker.verbose is True
         assert isinstance(chunker.rules, RecursiveRules)
         assert chunker.template is not None
@@ -115,7 +114,6 @@ class TestSlumberChunkerInitialization:
             rules=custom_rules,
             candidate_size=256,
             min_characters_per_chunk=50,
-            return_type="texts",
             verbose=False
         )
         
@@ -123,7 +121,6 @@ class TestSlumberChunkerInitialization:
         assert chunker.chunk_size == 2048
         assert chunker.candidate_size == 256
         assert chunker.min_characters_per_chunk == 50
-        assert chunker.return_type == "texts"
         assert chunker.verbose is False
         assert chunker.rules == custom_rules
     
@@ -530,8 +527,7 @@ class TestSlumberChunkerRepresentation:
             genie=mock_genie,
             chunk_size=2048,
             candidate_size=256,
-            min_characters_per_chunk=50,
-            return_type="texts"
+            min_characters_per_chunk=50
         )
         
         repr_str = repr(chunker)
@@ -541,7 +537,6 @@ class TestSlumberChunkerRepresentation:
         assert "chunk_size=2048" in repr_str
         assert "candidate_size=256" in repr_str
         assert "min_characters_per_chunk=50" in repr_str
-        assert "return_type=texts" in repr_str
     
     def test_repr_default_values(self, mock_genie: MockGenie) -> None:
         """Test __repr__ with default values."""
@@ -552,7 +547,6 @@ class TestSlumberChunkerRepresentation:
         assert "chunk_size=2048" in repr_str
         assert "candidate_size=128" in repr_str
         assert "min_characters_per_chunk=24" in repr_str
-        assert "return_type=chunks" in repr_str
 
 
 class TestSlumberChunkerIntegration:

--- a/tests/chunkers/test_token_chunker.py
+++ b/tests/chunkers/test_token_chunker.py
@@ -233,8 +233,7 @@ def test_token_chunker_repr(tiktokenizer: Encoding) -> None:
     assert repr(chunker) == (
         f"TokenChunker(tokenizer={chunker.tokenizer}, "
         f"chunk_size={chunker.chunk_size}, "
-        f"chunk_overlap={chunker.chunk_overlap}, "
-        f"return_type={chunker.return_type})"
+        f"chunk_overlap={chunker.chunk_overlap})"
     )
 
 
@@ -311,13 +310,12 @@ def test_token_chunker_indices_batch(tiktokenizer: Encoding, sample_text: str) -
 
 
 def test_token_chunker_return_type(tiktokenizer: Encoding, sample_text: str) -> None:
-    """Test that TokenChunker's return type is correctly set."""
+    """Test that TokenChunker returns Chunk objects by default."""
     chunker = TokenChunker(
         tokenizer=tiktokenizer,
         chunk_size=512,
         chunk_overlap=128,
-        return_type="texts",
     ) 
     chunks = chunker.chunk(sample_text)
-    assert all([type(chunk) is str for chunk in chunks])
-    assert all([len(tiktokenizer.encode(chunk)) <= 512 for chunk in chunks])
+    assert all([type(chunk) is Chunk for chunk in chunks])
+    assert all([len(tiktokenizer.encode(chunk.text)) <= 512 for chunk in chunks])


### PR DESCRIPTION
This pull request simplifies the `Chunker` classes across multiple files by removing the `return_type` parameter and standardizing the return type for chunking methods to always return chunks instead of optionally returning texts. Additionally, it cleans up type annotations and removes redundant code related to the `return_type`.

### Standardization of return types:

* [`src/chonkie/chunker/base.py`](diffhunk://#diff-10846354259652bb75e491a4bbce39e3909b204c82e70145936f910655ad97a0L35-R35): Updated methods like `__call__`, `_sequential_batch_processing`, `_parallel_batch_processing`, and `chunk` to always return `Sequence[Chunk]` instead of supporting both chunks and texts. Removed unnecessary `type: ignore` comments for return values. [[1]](diffhunk://#diff-10846354259652bb75e491a4bbce39e3909b204c82e70145936f910655ad97a0L35-R35) [[2]](diffhunk://#diff-10846354259652bb75e491a4bbce39e3909b204c82e70145936f910655ad97a0L67-R67) [[3]](diffhunk://#diff-10846354259652bb75e491a4bbce39e3909b204c82e70145936f910655ad97a0L80-R84) [[4]](diffhunk://#diff-10846354259652bb75e491a4bbce39e3909b204c82e70145936f910655ad97a0L103-R128)
* [`src/chonkie/chunker/code.py`](diffhunk://#diff-55afb1c1c6e6001a39e128592d27a02736a0621ebb4a360e69e5bd8fe6971ab3L35-L52): Removed the `return_type` parameter from the `CodeChunker` class and its methods. Updated `chunk` to always return `List[CodeChunk]`. Simplified the logic for determining the return value. [[1]](diffhunk://#diff-55afb1c1c6e6001a39e128592d27a02736a0621ebb4a360e69e5bd8fe6971ab3L35-L52) [[2]](diffhunk://#diff-55afb1c1c6e6001a39e128592d27a02736a0621ebb4a360e69e5bd8fe6971ab3L65) [[3]](diffhunk://#diff-55afb1c1c6e6001a39e128592d27a02736a0621ebb4a360e69e5bd8fe6971ab3L321-R317) [[4]](diffhunk://#diff-55afb1c1c6e6001a39e128592d27a02736a0621ebb4a360e69e5bd8fe6971ab3L348-R351)
* [`src/chonkie/chunker/late.py`](diffhunk://#diff-b8d4de839dd57d649b54fd5627f9cb77749311ee5e9965e7038f2bbddaed7277L75): Removed references to `return_type` in the `LateChunker` class and ensured `chunk` always returns `List[LateChunk]`. Adjusted comments to reflect the updated behavior. [[1]](diffhunk://#diff-b8d4de839dd57d649b54fd5627f9cb77749311ee5e9965e7038f2bbddaed7277L75) [[2]](diffhunk://#diff-b8d4de839dd57d649b54fd5627f9cb77749311ee5e9965e7038f2bbddaed7277L142-R141) [[3]](diffhunk://#diff-b8d4de839dd57d649b54fd5627f9cb77749311ee5e9965e7038f2bbddaed7277L170-R169)
* [`src/chonkie/chunker/neural.py`](diffhunk://#diff-daefb38249142a820879f628fc044936d962b23a2eba60a7e852e451383c4692L9-R9): Removed the `return_type` parameter from the `NeuralChunker` class and its methods. Updated `chunk` to always return `List[Chunk]`. Simplified the logic for determining the return value. [[1]](diffhunk://#diff-daefb38249142a820879f628fc044936d962b23a2eba60a7e852e451383c4692L9-R9) [[2]](diffhunk://#diff-daefb38249142a820879f628fc044936d962b23a2eba60a7e852e451383c4692L49) [[3]](diffhunk://#diff-daefb38249142a820879f628fc044936d962b23a2eba60a7e852e451383c4692L72-R71) [[4]](diffhunk://#diff-daefb38249142a820879f628fc044936d962b23a2eba60a7e852e451383c4692L82) [[5]](diffhunk://#diff-daefb38249142a820879f628fc044936d962b23a2eba60a7e852e451383c4692L126) [[6]](diffhunk://#diff-daefb38249142a820879f628fc044936d962b23a2eba60a7e852e451383c4692L207-R210) [[7]](diffhunk://#diff-daefb38249142a820879f628fc044936d962b23a2eba60a7e852e451383c4692L227-R231)
* [`src/chonkie/chunker/recursive.py`](diffhunk://#diff-8bbe8a372641303a22785a4d84abd72a02d9cad7afe7d7055d0f9581cae268b7L9-R9): Removed the `return_type` parameter from the `RecursiveChunker` class and its methods. Updated `chunk` and `_recursive_chunk` to always return `Sequence[RecursiveChunk]`. Simplified logic for handling recursive chunking. [[1]](diffhunk://#diff-8bbe8a372641303a22785a4d84abd72a02d9cad7afe7d7055d0f9581cae268b7L9-R9) [[2]](diffhunk://#diff-8bbe8a372641303a22785a4d84abd72a02d9cad7afe7d7055d0f9581cae268b7L41) [[3]](diffhunk://#diff-8bbe8a372641303a22785a4d84abd72a02d9cad7afe7d7055d0f9581cae268b7L51) [[4]](diffhunk://#diff-8bbe8a372641303a22785a4d84abd72a02d9cad7afe7d7055d0f9581cae268b7L60-L65) [[5]](diffhunk://#diff-8bbe8a372641303a22785a4d84abd72a02d9cad7afe7d7055d0f9581cae268b7L75-L85) [[6]](diffhunk://#diff-8bbe8a372641303a22785a4d84abd72a02d9cad7afe7d7055d0f9581cae268b7L98) [[7]](diffhunk://#diff-8bbe8a372641303a22785a4d84abd72a02d9cad7afe7d7055d0f9581cae268b7L111) [[8]](diffhunk://#diff-8bbe8a372641303a22785a4d84abd72a02d9cad7afe7d7055d0f9581cae268b7L127) [[9]](diffhunk://#diff-8bbe8a372641303a22785a4d84abd72a02d9cad7afe7d7055d0f9581cae268b7L317-L337) [[10]](diffhunk://#diff-8bbe8a372641303a22785a4d84abd72a02d9cad7afe7d7055d0f9581cae268b7L363-R354)

### Cleanup of type annotations:

* Removed `Literal` imports and references to `Literal["chunks", "texts"]` in type annotations across all affected files. This change simplifies the type definitions and aligns with the removal of the `return_type` parameter. [[1]](diffhunk://#diff-daefb38249142a820879f628fc044936d962b23a2eba60a7e852e451383c4692L9-R9) [[2]](diffhunk://#diff-8bbe8a372641303a22785a4d84abd72a02d9cad7afe7d7055d0f9581cae268b7L9-R9)

These changes streamline the `Chunker` classes, making their behavior more predictable and reducing complexity in type handling.