### PR TITLE
Feat: Bump version and add pre-built wheels for windows to avoid #212

### DIFF
--- a/.github/workflows/python-publish-wheels.yml
+++ b/.github/workflows/python-publish-wheels.yml
@@ -16,8 +16,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # Start with just Linux and one macOS to test
-        os: [ubuntu-latest, macos-13]
+        # Linux, macOS, and Windows wheels
+        os: [ubuntu-latest, macos-13, windows-latest]
 
     steps:
       - uses: actions/checkout@v4
@@ -38,6 +38,8 @@ jobs:
           CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux*"
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
           CIBW_MANYLINUX_AARCH64_IMAGE: manylinux_2_28
+          # Ensure Cython extensions work properly on Windows
+          CIBW_ENVIRONMENT_WINDOWS: "PIP_PREFER_BINARY=1"
 
       - uses: actions/upload-artifact@v4
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "chonkie"
-version = "1.1.0"
+version = "1.1.1a0"
 description = "🦛 CHONK your texts with Chonkie ✨ - The no-nonsense chunking library"
 readme = "README.md"
 requires-python = ">=3.9"
@@ -62,7 +62,11 @@ tokenizers = ["tokenizers>=0.16.0"]
 tiktoken = ["tiktoken>=0.5.0"]
 
 # Optional dependencies for the chunkers
-code = ["tree-sitter>=0.20.0", "tree-sitter-language-pack>=0.7.0", "magika>=0.6.0, <0.7.0"]
+code = [
+    "tree-sitter>=0.20.0",
+    "tree-sitter-language-pack>=0.7.0",
+    "magika>=0.6.0, <0.7.0",
+]
 neural = ["transformers>=4.0.0", "torch>=2.0.0, <3.0"]
 
 # Optional dependencies for the embeddings
@@ -156,7 +160,7 @@ name = "chonkie.chunker.c_extensions.merge"
 sources = ["src/chonkie/chunker/c_extensions/merge.pyx"]
 
 [tool.setuptools.dynamic]
-version = {attr = "chonkie.__version__"}
+version = { attr = "chonkie.__version__" }
 
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
 requires = ["setuptools>=45", "wheel", "cython>=3.0.0"]
 build-backend = "setuptools.build_meta"
 
+
 [project]
 name = "chonkie"
 version = "1.1.1a0"
@@ -158,9 +159,6 @@ sources = ["src/chonkie/chunker/c_extensions/split.pyx"]
 [[tool.setuptools.ext-modules]]
 name = "chonkie.chunker.c_extensions.merge"
 sources = ["src/chonkie/chunker/c_extensions/merge.pyx"]
-
-[tool.setuptools.dynamic]
-version = { attr = "chonkie.__version__" }
 
 
 [tool.ruff]

--- a/src/chonkie/__init__.py
+++ b/src/chonkie/__init__.py
@@ -69,7 +69,7 @@ from .utils import (
 )
 
 # This hippo grows with every release 🦛✨~
-__version__ = "1.1.0"
+__version__ = "1.1.1a0"
 __name__ = "chonkie"
 __author__ = "🦛 Chonkie Inc"
 


### PR DESCRIPTION
This pull request includes updates to the CI workflow, versioning, and dependency formatting for the `chonkie` project. The most notable changes include adding Windows support to the build matrix, introducing a pre-release version, and improving the readability of dependency lists.

### CI Workflow Updates:
* [`.github/workflows/python-publish-wheels.yml`](diffhunk://#diff-2849a829827cd04b191e7fd46d1fa37c72f70a42743ab7f3f9ea4c5508a1582cL19-R20): Added Windows (`windows-latest`) to the build matrix for generating wheels, alongside Linux and macOS. This expands platform support.
* [`.github/workflows/python-publish-wheels.yml`](diffhunk://#diff-2849a829827cd04b191e7fd46d1fa37c72f70a42743ab7f3f9ea4c5508a1582cR41-R42): Introduced `CIBW_ENVIRONMENT_WINDOWS` to set `PIP_PREFER_BINARY=1`, ensuring proper handling of Cython extensions on Windows.

### Versioning:
* `pyproject.toml` and `src/chonkie/__init__.py`: Updated the project version from `1.1.0` to `1.1.1a0`, marking it as a pre-release. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R7) [[2]](diffhunk://#diff-44a557df57b150a7b71a0b691e66e501f00f8983cc9c66dee9309aaf738bd408L72-R72)

### Dependency Formatting:
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L65-R69): Reformatted the `code` optional dependency list for better readability by using a multi-line structure.