### PR TITLE
fix: export EmbeddingsRegistry in embeddings module

### DIFF
--- a/src/chonkie/embeddings/__init__.py
+++ b/src/chonkie/embeddings/__init__.py
@@ -7,6 +7,7 @@ from .gemini import GeminiEmbeddings
 from .jina import JinaEmbeddings
 from .model2vec import Model2VecEmbeddings
 from .openai import OpenAIEmbeddings
+from .registry import EmbeddingsRegistry
 from .sentence_transformer import SentenceTransformerEmbeddings
 from .voyageai import VoyageAIEmbeddings
 
@@ -21,4 +22,5 @@ __all__ = [
     "AutoEmbeddings",
     "JinaEmbeddings",
     "VoyageAIEmbeddings",
+    "EmbeddingsRegistry",
 ]


### PR DESCRIPTION
## 1 Problem

While following the official documentation tutorial for creating [custom embedding handlers](https://docs.chonkie.ai/python-sdk/embeddings/custom-embeddings), I encountered an ImportError when trying to import EmbeddingsRegistry:

```bash
Traceback (most recent call last):
  File "/root/embedding/xxx.py", line 11, in <module>
    from chonkie.embeddings import BaseEmbeddings, EmbeddingsRegistry, AutoEmbeddings
ImportError: cannot import name 'EmbeddingsRegistry' from 'chonkie.embeddings'
(/root/embedding/.venv/lib/python3.12/site-packages/chonkie/embeddings/__init__.py)
```

The documentation at [docs/python-sdk/embeddings/custom-embeddings.mdx](https://github.com/chonkie-inc/chonkie/blob/8bb30ee3f661a332cf52c561f021295452d0c8c8/docs/python-sdk/embeddings/custom-embeddings.mdx?plain=1#L54) shows:

```python
from chonkie.embeddings import EmbeddingsRegistry
```

However, EmbeddingsRegistry was not exported in the [`__init__.py`](https://github.com/chonkie-inc/chonkie/blob/main/src/chonkie/embeddings/__init__.py) file.

## 2 Solution

This PR adds EmbeddingsRegistry to the exports in [`src/chonkie/embeddings/__init__.py`](https://github.com/chonkie-inc/chonkie/blob/main/src/chonkie/embeddings/__init__.py) to match the documented usage.

### 2.1 Changes Made

- Added from .registry import EmbeddingsRegistry to the imports
- Added "EmbeddingsRegistry" to the __all__ list

### 2.2 Alternative Considered

I initially worked around this by using:

```python
from chonkie.embeddings.registry import EmbeddingsRegistry
```

However, it's better to fix the module exports to match the documentation for a cleaner API.

## 3 Summary

This makes the API consistent with the documentation and improves the developer experience when creating custom embeddings handlers.