### PR TITLE
docs: fix url

### DIFF
--- a/docs/python-sdk/getting-started/introduction.mdx
+++ b/docs/python-sdk/getting-started/introduction.mdx
@@ -78,7 +78,7 @@ pip install chonkie[all]
 
 <Note>
   Chonkie follows a special approach to dependencies, keeping the base installation lightweight while allowing you to add extra features as and when needed.
-  Please check the [Installation](/installation) page for more details.
+  Please check the [Installation](/python-sdk/getting-started/installation) page for more details.
 </Note>
 
 Release the CHONK! 🦛✨


### PR DESCRIPTION
This pull request makes a minor update to the documentation for the Python SDK, clarifying the link to the Installation page.

* Updated the reference in the installation note to point to the correct Installation documentation at `/python-sdk/getting-started/installation` instead of `/installation`.