### PR TITLE
update init file

### DIFF
--- a/src/chonkie/__init__.py
+++ b/src/chonkie/__init__.py
@@ -1,5 +1,8 @@
 """Main package for Chonkie."""
 
+# ruff: noqa: F401
+# above line tells ruff to ignore unused imports in this file
+
 from .chef import (
     BaseChef,
     TextChef,
@@ -87,115 +90,3 @@ from .utils import (
 __version__ = "1.2.1"
 __name__ = "chonkie"
 __author__ = "🦛 Chonkie Inc"
-
-
-# Add basic package metadata to __all__
-__all__ = [
-    "__name__",
-    "__version__",
-    "__author__",
-]
-
-# Add all data classes to __all__
-__all__ += [
-    "Context",
-    "Chunk",
-    "RecursiveChunk",
-    "RecursiveLevel",
-    "RecursiveRules",
-    "SentenceChunk",
-    "SemanticChunk",
-    "Sentence",
-    "SemanticSentence",
-    "LateChunk",
-    "CodeChunk",
-    "LanguageConfig",
-    "MergeRule",
-    "SplitRule",
-]
-
-# Add all tokenizer classes to __all__
-__all__ += [
-    "Tokenizer",
-    "CharacterTokenizer",
-    "WordTokenizer",
-]
-
-# Add all chunker classes to __all__
-__all__ += [
-    "BaseChunker",
-    "TokenChunker",
-    "SentenceChunker",
-    "SemanticChunker",
-    "RecursiveChunker",
-    "LateChunker",
-    "CodeChunker",
-    "SlumberChunker",
-    "NeuralChunker",
-]
-
-# Add all cloud classes to __all__
-__all__ += [
-    "auth",
-    "chunker",
-    "refineries",
-]
-
-# Add all embeddings classes to __all__
-__all__ += [
-    "BaseEmbeddings",
-    "Model2VecEmbeddings",
-    "SentenceTransformerEmbeddings",
-    "OpenAIEmbeddings",
-    "CohereEmbeddings",
-    "GeminiEmbeddings",
-    "AutoEmbeddings",
-    "JinaEmbeddings",
-    "VoyageAIEmbeddings",
-]
-
-# Add all refinery classes to __all__
-__all__ += [
-    "BaseRefinery",
-    "OverlapRefinery",
-    "EmbeddingsRefinery",
-]
-
-# Add all utils classes to __all__
-__all__ += [
-    "Hubbie",
-    "Visualizer",
-]
-
-# Add all genie classes to __all__
-__all__ += [
-    "BaseGenie",
-    "GeminiGenie",
-    "OpenAIGenie",
-]
-
-# Add all friends classes to __all__
-__all__ += [
-    "BasePorter",
-    "BaseHandshake",
-    "JSONPorter",
-    "ChromaHandshake",
-    "MongoDBHandshake",
-    "PgvectorHandshake",
-    "PineconeHandshake",
-    "QdrantHandshake",
-    "WeaviateHandshake",
-    "TurbopufferHandshake",
-]
-
-# Add all the chefs to __all__
-__all__ += [
-    "BaseChef",
-    "TextChef",
-]
-
-# Add all the fetchers to __all__
-__all__ += [
-    "BaseFetcher",
-    "FileFetcher",
-]


### PR DESCRIPTION
fixes #265 
the legacy was broken due to the `__all__` that we had in our main init file.
we could not import the SemanticChunker since the name is the same as the old implementation and i did not find out how to include the entire module in the `__all__` I chose to get rid of it, since we have lazy imports all over our code base this should be safe (will confirm after the pr is deployed).
as for the ruff and the linter issues i did suppress ruff using `# ruff: noqa: F401` at the top of the file