### PR TITLE
Correct faulty import in LateChunker docs

### DIFF
--- a/docs/python-sdk/chunkers/late-chunker.mdx
+++ b/docs/python-sdk/chunkers/late-chunker.mdx
@@ -46,7 +46,7 @@ chunker = LateChunker(
 You can also initialize the LateChunker using a recipe. Recipes are pre-defined rules for common chunking tasks.
 Find all available recipes on our Hugging Face Hub [here](https://huggingface.co/datasets/chonkie-ai/recipes).
 ```python
-from chonkie import LateChunk
+from chonkie import LateChunker
 
 # Initialize the late chunker to chunk Markdown
 chunker = LateChunker.from_recipe("markdown", lang="en")


### PR DESCRIPTION
Stumbled upon a faulty import in the docs:

`from chonkie import LateChunk` to `from chonkie import LateChunker`