### PR TITLE
Chore: remove -O3 compiling parameter

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,8 @@ extensions = [
         "chonkie.chunker.c_extensions.merge",
         [os.path.join(c_extensions_dir, "merge.pyx")],
     ),
+    # The -O3 compile flag was removed as it caused issues with re-installing
+    # the package in editable mode.
     Extension(
         "chonkie.chunker.c_extensions.savgol",
         [os.path.join(c_extensions_dir, "savgol.pyx")],


### PR DESCRIPTION
this generated an issue when RE-installing the current package in editable mode