### PR TITLE
Fix: All chunkers now return `Chunk` type only

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -249,10 +249,10 @@ The `SentenceChunker` is a chunker that splits the text into sentences and then 
 
 **Methods:**
 
-- `chunk(text: str) -> List[SentenceChunk]`: Chunks a string into a list of `SentenceChunk` objects.
-- `chunk_batch(texts: List[str]) -> List[List[SentenceChunk]]`: Chunks a list of strings into a list of lists of `SentenceChunk` objects. (Inherited)
+- `chunk(text: str) -> List[Chunk]`: Chunks a string into a list of `Chunk` objects.
+- `chunk_batch(texts: List[str]) -> List[List[Chunk]]`: Chunks a list of strings into a list of lists of `Chunk` objects. (Inherited)
 - `from_recipe(name: str, lang: str, **kwargs) -> SentenceChunker`: Creates a `SentenceChunker` instance using pre-defined recipes from the [Chonkie Recipe Store](https://huggingface.co/datasets/chonkie-ai/recipes). This allows easy configuration for specific languages or splitting behaviors.
-- `__call__(text: str) -> Union[List[SentenceChunk], List[List[SentenceChunk]]]`: Chunks a string or list of strings. Calls `chunk` or `chunk_batch` depending on input type. (Inherited)
+- `__call__(text: str) -> Union[List[Chunk], List[List[Chunk]]]`: Chunks a string or list of strings. Calls `chunk` or `chunk_batch` depending on input type. (Inherited)
 
 **Examples:**
 
@@ -276,7 +276,7 @@ for chunk in chunks:
     print(f"Token Count: {chunk.token_count}")
     print(f"Start Index: {chunk.start_index}")
     print(f"End Index: {chunk.end_index}")
-    print(f"Number of Sentences: {len(chunk.sentences)}") # SentenceChunk specific attribute
+    # Note: sentence information is no longer directly accessible in the base Chunk type
     print("-" * 10)
 ```
 
@@ -1413,7 +1413,7 @@ print("Created HNSW index")
 results = handshake.search(
     "metadata filtering",
     limit=2,
-    filters={"chunk_type": {"$eq": "SentenceChunk"}}
+    filters={"chunk_type": {"$eq": "Chunk"}}
 )
 
 for result in results:

--- a/docs/python-sdk/changelog.mdx
+++ b/docs/python-sdk/changelog.mdx
@@ -6,6 +6,45 @@ icon: "hippo"
 iconType: "solid"
 ---
 
+<Update label="v1.3.0 (Upcoming)">
+  # v1.3.0 Release Highlights ✨
+
+  ## Breaking Changes
+
+  - **Unified Chunk Type**: All chunkers now return the base `Chunk` type instead of specialized types (`SentenceChunk`, `RecursiveChunk`, `SemanticChunk`, `CodeChunk`). This simplifies the API and improves interoperability between different chunkers and refineries.
+
+  - **New `embedding` Attribute**: The base `Chunk` type now includes an optional `embedding` attribute that can store embedding vectors (as lists or numpy arrays). This is automatically populated by `EmbeddingsRefinery` and certain chunkers like `LateChunker`.
+
+  ## Migration Guide
+
+  If you were relying on specialized chunk attributes:
+  - `SentenceChunk.sentences` → No longer available in base Chunk
+  - `SemanticChunk.sentences` → No longer available in base Chunk
+  - `CodeChunk.nodes` → No longer available in base Chunk
+  - `RecursiveChunk.level` → No longer available in base Chunk
+
+  All chunkers now consistently return `Chunk` objects with:
+  ```python
+  @dataclass
+  class Chunk:
+      text: str
+      start_index: int
+      end_index: int
+      token_count: int
+      context: Optional[Context] = None
+      embedding: Optional[Any] = None  # NEW!
+  ```
+
+  ## Import Changes
+
+  When importing the Chunk type, use:
+  ```python
+  from chonkie.types import Chunk
+  ```
+
+  The specialized types are deprecated but remain available for backward compatibility in the legacy module.
+</Update>
+
 <Update label="v1.0.6">
   # v1.0.6 Release Highlights ✨
 

--- a/docs/python-sdk/chunkers/code-chunker.mdx
+++ b/docs/python-sdk/chunkers/code-chunker.mdx
@@ -73,7 +73,7 @@ chunker = CodeChunker(
     type="bool"
     default="False"
 >
-    Whether to include the list of corresponding AST `Node` objects within each `CodeChunk`.
+    Whether to include AST node information (Note: with the base Chunk type, node information is not stored).
 </ParamField>
 
 
@@ -126,15 +126,18 @@ batch_chunks = chunker(["int main() { return 0; }", "package main\nimport \"fmt\
 
 ## Return Type
 
-CodeChunker returns chunks as `CodeChunk` objects:
+CodeChunker returns chunks as `Chunk` objects:
 
 ```python
 @dataclass
-class CodeChunk(Chunk):
+class Chunk:
     text: str           # The chunk text (code snippet)
     start_index: int    # Starting position in original code
     end_index: int      # Ending position in original code
     token_count: int    # Number of tokens in chunk
-    lang: Optional[str] = None # Language of the code chunk
-    nodes: Optional[List[Node]] = None # List of AST nodes if include_nodes=True
+    context: Optional[Context] = None    # Optional context metadata
+    embedding: Optional[Any] = None      # Optional embedding vector
 ```
+
+> [!NOTE]
+> As of version 1.3.0, CodeChunker returns the base `Chunk` type instead of the specialized `CodeChunk` type. This simplifies integration with other chunkers and refineries.

--- a/docs/python-sdk/chunkers/late-chunker.mdx
+++ b/docs/python-sdk/chunkers/late-chunker.mdx
@@ -130,7 +130,7 @@ LateChunker returns `LateChunk` objects with optimized storage using slots:
 
 ```python
 @dataclass
-class LateChunk(RecursiveChunk):
+class LateChunk(Chunk):
     text: str  # The text of the chunk.
     start_index: int  # The start index of the chunk.
     end_index: int  # The end index of the chunk.

--- a/docs/python-sdk/chunkers/recursive-chunker.mdx
+++ b/docs/python-sdk/chunkers/recursive-chunker.mdx
@@ -123,16 +123,15 @@ batch_chunks = chunker(["Text 1. More text.", "Text 2. More."])
 
 ## Return Type
 
-The RecursiveChunker returns chunks as `RecursiveChunk` objects with additional sentence metadata:
+The RecursiveChunker returns chunks as `Chunk` objects:
 
 ```python
 @dataclass
-class RecursiveChunk(Chunk):
+class Chunk:
     text: str           # The chunk text
     start_index: int    # Starting position in original text
     end_index: int      # Ending position in original text
     token_count: int    # Number of tokens in Chunk
-    level: int          # Level of the chunk in the recursive tree
 ```
 
 

--- a/docs/python-sdk/chunkers/sentence-chunker.mdx
+++ b/docs/python-sdk/chunkers/sentence-chunker.mdx
@@ -166,21 +166,13 @@ SentenceChunker supports multiple tokenizer backends:
 
 ## Return Type
 
-SentenceChunker returns chunks as `SentenceChunk` objects with additional sentence metadata:
+SentenceChunker returns chunks as `Chunk` objects:
 
 ```python
 @dataclass
-class Sentence:
-    text: str           # The sentence text
-    start_index: int    # Starting position in original text
-    end_index: int      # Ending position in original text
-    token_count: int    # Number of tokens in sentence
-
-@dataclass
-class SentenceChunk(Chunk):
+class Chunk:
     text: str           # The chunk text
     start_index: int    # Starting position in original text
     end_index: int      # Ending position in original text
     token_count: int    # Number of tokens in chunk
-    sentences: List[Sentence]  # List of sentences in chunk
 ```

--- a/llms.txt
+++ b/llms.txt
@@ -19,6 +19,8 @@ Unfortunately, we do need docs for Chonkie (we tried!). While official docs are 
 - [📦 Installation](#-installation)
   - [Optional Dependencies](#optional-dependencies)
 - [Usage](#usage)
+- [Types and Data Structures](#types-and-data-structures)
+  - [The `Chunk` Type](#the-chunk-type)
 - [CHONKosophy](#chonkosophy)
   - [How does Chonkie think about chunking?](#how-does-chonkie-think-about-chunking)
 - [Chunkers](#chunkers)
@@ -128,7 +130,27 @@ for chunk in chunks:
     print(chunk.end_index)
 ```
 
-Refer to the types reference below for more information on the `Chunk` object.
+## Types and Data Structures
+
+### The `Chunk` Type
+
+All chunkers in Chonkie now return the base `Chunk` type for consistency and simplicity. The `Chunk` type is a dataclass with the following attributes:
+
+```python
+@dataclass
+class Chunk:
+    text: str                    # The text content of the chunk
+    start_index: int             # Starting position in original text
+    end_index: int               # Ending position in original text
+    token_count: int             # Number of tokens in the chunk
+    context: Optional[Context] = None    # Optional context metadata
+    embedding: Optional[Any] = None      # Optional embedding vector
+```
+
+The `embedding` attribute can store embedding vectors (as lists or numpy arrays) which are automatically added when using `EmbeddingsRefinery` or certain chunkers like `LateChunker`.
+
+> [!NOTE]
+> As of version 1.3.0, specialized chunk types like `SentenceChunk`, `RecursiveChunk`, `SemanticChunk`, and `CodeChunk` have been deprecated. All chunkers now return the base `Chunk` type. This simplifies the API and makes it easier to chain different chunkers and refineries together.
 
 ## CHONKosophy
 
@@ -249,7 +271,7 @@ The `SentenceChunker` is a chunker that splits the text into sentences and then 
 
 **Methods:**
 
-- `chunk(text: str) -> List[Chunk]`: Chunks a string into a list of `Chunk` objects.
+- `chunk(text: str) -> List[Chunk]`: Chunks a string into a list of `Chunk` objects. Returns the base `Chunk` type.
 - `chunk_batch(texts: List[str]) -> List[List[Chunk]]`: Chunks a list of strings into a list of lists of `Chunk` objects. (Inherited)
 - `from_recipe(name: str, lang: str, **kwargs) -> SentenceChunker`: Creates a `SentenceChunker` instance using pre-defined recipes from the [Chonkie Recipe Store](https://huggingface.co/datasets/chonkie-ai/recipes). This allows easy configuration for specific languages or splitting behaviors.
 - `__call__(text: str) -> Union[List[Chunk], List[List[Chunk]]]`: Chunks a string or list of strings. Calls `chunk` or `chunk_batch` depending on input type. (Inherited)
@@ -276,7 +298,7 @@ for chunk in chunks:
     print(f"Token Count: {chunk.token_count}")
     print(f"Start Index: {chunk.start_index}")
     print(f"End Index: {chunk.end_index}")
-    # Note: sentence information is no longer directly accessible in the base Chunk type
+    # All chunkers now return the base Chunk type for consistency
     print("-" * 10)
 ```
 

--- a/src/chonkie/__init__.py
+++ b/src/chonkie/__init__.py
@@ -68,7 +68,6 @@ from .types import (
     Chunk,
     Context,
     LanguageConfig,
-    LateChunk,
     MergeRule,
     RecursiveLevel,
     RecursiveRules,

--- a/src/chonkie/__init__.py
+++ b/src/chonkie/__init__.py
@@ -66,14 +66,12 @@ from .tokenizer import (
 )
 from .types import (
     Chunk,
-    CodeChunk,
     Context,
     LanguageConfig,
     LateChunk,
     MergeRule,
     RecursiveLevel,
     RecursiveRules,
-    SemanticChunk,
     SemanticSentence,
     Sentence,
     SplitRule,

--- a/src/chonkie/__init__.py
+++ b/src/chonkie/__init__.py
@@ -71,7 +71,6 @@ from .types import (
     LanguageConfig,
     LateChunk,
     MergeRule,
-    RecursiveChunk,
     RecursiveLevel,
     RecursiveRules,
     SemanticChunk,

--- a/src/chonkie/__init__.py
+++ b/src/chonkie/__init__.py
@@ -77,7 +77,6 @@ from .types import (
     SemanticChunk,
     SemanticSentence,
     Sentence,
-    SentenceChunk,
     SplitRule,
 )
 from .utils import (

--- a/src/chonkie/chunker/base.py
+++ b/src/chonkie/chunker/base.py
@@ -8,7 +8,7 @@ from typing import Any, Callable, Sequence, Union
 from tqdm import tqdm
 
 from chonkie.tokenizer import Tokenizer
-from chonkie.types.base import Chunk
+from chonkie.types import Chunk
 
 
 class BaseChunker(ABC):

--- a/src/chonkie/chunker/code.py
+++ b/src/chonkie/chunker/code.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, Any, List, Literal, Tuple, Union
 
 from chonkie.chunker.base import BaseChunker
 from chonkie.tokenizer import Tokenizer
-from chonkie.types.code import CodeChunk
+from chonkie.types import Chunk
 
 if TYPE_CHECKING:
     from typing import Any
@@ -297,24 +297,23 @@ class CodeChunker(BaseChunker):
     def _create_chunks(self,
                        texts: List[str],
                        token_counts: List[int],
-                       node_groups: List[List["Node"]]) -> List[CodeChunk]:
+                       node_groups: List[List["Node"]]) -> List[Chunk]:
         """Create Code Chunks."""
         chunks = []
         current_index = 0
-        for i in range(len(texts)): 
+        for i in range(len(texts)):
             text = texts[i]
             token_count = token_counts[i]
             node_group = node_groups[i] if self.include_nodes else None
 
-            chunks.append(CodeChunk(text=text, 
-                                    start_index=current_index, 
-                                    end_index=current_index + len(text),
-                                    token_count=token_count,
-                                    nodes=None if not self.include_nodes or not node_group else [{"type": node.type, "text": node.text.decode() if node.text else ""} for node in node_group]))  # type: ignore[attr-defined]
+            chunks.append(Chunk(text=text,
+                                start_index=current_index,
+                                end_index=current_index + len(text),
+                                token_count=token_count))  # type: ignore[attr-defined]
             current_index += len(text)
         return chunks
         
-    def chunk(self, text: str) -> List[CodeChunk]:
+    def chunk(self, text: str) -> List[Chunk]:
         """Recursively chunks the code based on context from tree-sitter."""
         if not text.strip(): # Handle empty or whitespace-only input
             return []

--- a/src/chonkie/chunker/late.py
+++ b/src/chonkie/chunker/late.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any, List, Optional, Union
 # Get all the Chonkie imports
 from chonkie.chunker.recursive import RecursiveChunker
 from chonkie.embeddings.sentence_transformer import SentenceTransformerEmbeddings
-from chonkie.types import LateChunk, RecursiveRules
+from chonkie.types import Chunk, RecursiveRules
 
 if TYPE_CHECKING:
     try:
@@ -129,7 +129,7 @@ class LateChunker(RecursiveChunker):
             )
         return embs
 
-    def chunk(self, text: str) -> List[LateChunk]: # type: ignore
+    def chunk(self, text: str) -> List[Chunk]: # type: ignore
         """Chunk the text via LateChunking."""
         # This would first call upon the _recursive_chunk method
         # and then use the embedding model to get the token token_embeddings
@@ -163,12 +163,12 @@ class LateChunker(RecursiveChunker):
         # Split the token embeddings into chunks based on the token counts
         late_embds = self._get_late_embeddings(token_embeddings, token_counts)
 
-        # Wrap it all up in LateChunks
+        # Wrap it all up in Chunks with embeddings
         result = []
         for chunk, token_count, embedding in zip(chunks, token_counts, late_embds):
-            # Note: LateChunker always returns chunks, so chunk is always a RecursiveChunk
+            # Note: LateChunker always returns chunks, so chunk is always a Chunk
             result.append(
-                LateChunk(
+                Chunk(
                     text=chunk.text,  # type: ignore[attr-defined]
                     start_index=chunk.start_index,  # type: ignore[attr-defined]
                     end_index=chunk.end_index,  # type: ignore[attr-defined]

--- a/src/chonkie/chunker/recursive.py
+++ b/src/chonkie/chunker/recursive.py
@@ -10,7 +10,7 @@ from typing import Any, Callable, List, Optional, Sequence, Tuple, Union
 
 from chonkie.chunker.base import BaseChunker
 from chonkie.types import (
-    RecursiveChunk,
+    Chunk,
     RecursiveLevel,
     RecursiveRules,
 )
@@ -188,8 +188,8 @@ class RecursiveChunker(BaseChunker):
         token_count: int,
         level: int,
         start_offset: int
-    ) -> RecursiveChunk:
-        """Create a RecursiveChunk object with indices based on the current offset.
+    ) -> Chunk:
+        """Create a Chunk object with indices based on the current offset.
 
         This method calculates the start and end indices of the chunk using the provided start_offset and the length of the text,
         avoiding a slower full-text search for efficiency.
@@ -201,15 +201,14 @@ class RecursiveChunker(BaseChunker):
             start_offset (int): The starting offset in the original text.
 
         Returns:
-            RecursiveChunk: A chunk object with calculated start and end indices, text, token count and level.
+            Chunk: A chunk object with calculated start and end indices, text, and token count.
 
         """
-        return RecursiveChunk(
+        return Chunk(
             text=text,
             start_index=start_offset,
             end_index=start_offset + len(text),
             token_count=token_count,
-            level=level,
         )
 
     def _merge_splits(
@@ -302,7 +301,7 @@ class RecursiveChunker(BaseChunker):
 
     def _recursive_chunk(
         self, text: str, level: int = 0, start_offset: int =0
-    ) -> Sequence[RecursiveChunk]:
+    ) -> Sequence[Chunk]:
         """Recursive helper for core chunking."""
         if not text:
             return []
@@ -339,7 +338,7 @@ class RecursiveChunker(BaseChunker):
             )
 
         # Chunk long merged splits
-        chunks: List[RecursiveChunk] = []
+        chunks: List[Chunk] = []
         current_offset = start_offset
         for split, token_count in zip(merged, combined_token_counts):
             if token_count > self.chunk_size:
@@ -351,7 +350,7 @@ class RecursiveChunker(BaseChunker):
             current_offset += len(split)
         return chunks
 
-    def chunk(self, text: str) -> Sequence[RecursiveChunk]:
+    def chunk(self, text: str) -> Sequence[Chunk]:
         """Recursively chunk text.
 
         Args:

--- a/src/chonkie/chunker/sentence.py
+++ b/src/chonkie/chunker/sentence.py
@@ -11,7 +11,8 @@ from bisect import bisect_left
 from itertools import accumulate
 from typing import Any, Callable, List, Literal, Optional, Sequence, Union
 
-from chonkie.types.sentence import Sentence, SentenceChunk
+from chonkie.types.base import Chunk
+from chonkie.types.sentence import Sentence
 from chonkie.utils import Hubbie
 
 from .base import BaseChunker
@@ -255,7 +256,7 @@ class SentenceChunker(BaseChunker):
             for sent, pos, count in zip(sentence_texts, positions, token_counts)
         ]
 
-    def _create_chunk(self, sentences: List[Sentence]) -> SentenceChunk:
+    def _create_chunk(self, sentences: List[Sentence]) -> Chunk:
         """Create a chunk from a list of sentences.
 
         Args:
@@ -266,21 +267,20 @@ class SentenceChunker(BaseChunker):
 
         """
         chunk_text = "".join([sentence.text for sentence in sentences])
-        
+
         # We calculate the token count here, as sum of the token counts of the sentences
         # does not match the token count of the chunk as a whole for some reason. That's to
         # say that the tokenizer encodes the text differently when the text is joined together.
         token_count = self.tokenizer.count_tokens(chunk_text)
 
-        return SentenceChunk(
+        return Chunk(
             text=chunk_text,
             start_index=sentences[0].start_index,
             end_index=sentences[-1].end_index,
             token_count=token_count,
-            sentences=sentences,
         )
 
-    def chunk(self, text: str) -> Sequence[SentenceChunk]:
+    def chunk(self, text: str) -> Sequence[Chunk]:
         """Split text into overlapping chunks based on sentences while respecting token limits.
 
         Args:

--- a/src/chonkie/chunker/sentence.py
+++ b/src/chonkie/chunker/sentence.py
@@ -11,8 +11,7 @@ from bisect import bisect_left
 from itertools import accumulate
 from typing import Any, Callable, List, Literal, Optional, Sequence, Union
 
-from chonkie.types.base import Chunk
-from chonkie.types.sentence import Sentence
+from chonkie.types import Chunk, Sentence
 from chonkie.utils import Hubbie
 
 from .base import BaseChunker

--- a/src/chonkie/chunker/token.py
+++ b/src/chonkie/chunker/token.py
@@ -9,7 +9,7 @@ from typing import Any, Generator, List, Sequence, Union
 from tqdm import trange
 
 from chonkie.chunker.base import BaseChunker
-from chonkie.types.base import Chunk
+from chonkie.types import Chunk
 
 
 class TokenChunker(BaseChunker):

--- a/src/chonkie/cloud/chunker/code.py
+++ b/src/chonkie/cloud/chunker/code.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, List, Literal, Optional, Union, cast
 import requests
 
 from chonkie.cloud.file import FileManager
-from chonkie.types import CodeChunk
+from chonkie.types import Chunk
 
 from .base import CloudChunker
 
@@ -65,7 +65,7 @@ class CodeChunker(CloudChunker):
         # Initialize the file manager to upload files if needed
         self.file_manager = FileManager(api_key=self.api_key)
 
-    def chunk(self, text: Optional[Union[str, List[str]]] = None, file: Optional[str] = None) -> Union[List[CodeChunk], List[List[CodeChunk]]]:
+    def chunk(self, text: Optional[Union[str, List[str]]] = None, file: Optional[str] = None) -> Union[List[Chunk], List[List[Chunk]]]:
         """Chunk the code into a list of chunks.
 
         Args:
@@ -123,20 +123,20 @@ class CodeChunker(CloudChunker):
         try:
             if isinstance(text, list):
                 batch_result: List[List[Dict]] = cast(List[List[Dict]], response.json())
-                batch_chunks: List[List[CodeChunk]] = []
+                batch_chunks: List[List[Chunk]] = []
                 for chunk_list in batch_result:
                     curr_chunks = []
                     for chunk in chunk_list:
-                        curr_chunks.append(CodeChunk.from_dict(chunk))
+                        curr_chunks.append(Chunk.from_dict(chunk))
                     batch_chunks.append(curr_chunks)
                 return batch_chunks
             else:
                 single_result: List[Dict] = cast(List[Dict], response.json())
-                single_chunks: List[CodeChunk] = [CodeChunk.from_dict(chunk) for chunk in single_result]
+                single_chunks: List[Chunk] = [Chunk.from_dict(chunk) for chunk in single_result]
                 return single_chunks
         except Exception as error:
             raise ValueError(f"Error parsing the response: {error}") from error
 
-    def __call__(self, text: Optional[Union[str, List[str]]] = None, file: Optional[str] = None) -> Union[List[CodeChunk], List[List[CodeChunk]]]:
+    def __call__(self, text: Optional[Union[str, List[str]]] = None, file: Optional[str] = None) -> Union[List[Chunk], List[List[Chunk]]]:
         """Call the chunker."""
         return self.chunk(text=text, file=file)

--- a/src/chonkie/cloud/chunker/late.py
+++ b/src/chonkie/cloud/chunker/late.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Optional, Union, cast
 
 import requests
 
-from chonkie.types import LateChunk
+from chonkie.types import Chunk
 
 from .recursive import RecursiveChunker
 
@@ -44,7 +44,7 @@ class LateChunker(RecursiveChunker):
             lang=lang,
         )
 
-    def chunk(self, text: Optional[Union[str, List[str]]] = None, file: Optional[str] = None) -> Union[List[LateChunk], List[List[LateChunk]]]:
+    def chunk(self, text: Optional[Union[str, List[str]]] = None, file: Optional[str] = None) -> Union[List[Chunk], List[List[Chunk]]]:
         """Chunk the text or file into a list of late-interaction chunks via the Chonkie API.
 
         Args:
@@ -98,16 +98,16 @@ class LateChunker(RecursiveChunker):
             response.raise_for_status()  # Raise an exception for HTTP errors (4xx or 5xx)
             if isinstance(text, list):
                 batch_result: List[List[Dict]] = cast(List[List[Dict]], response.json())
-                batch_chunks: List[List[LateChunk]] = []
+                batch_chunks: List[List[Chunk]] = []
                 for chunk_list in batch_result:
                     curr_chunks = []
                     for chunk in chunk_list:
-                        curr_chunks.append(LateChunk.from_dict(chunk))
+                        curr_chunks.append(Chunk.from_dict(chunk))
                     batch_chunks.append(curr_chunks)
                 return batch_chunks
             else:
                 single_result: List[Dict] = cast(List[Dict], response.json())
-                single_chunks: List[LateChunk] = [LateChunk.from_dict(chunk) for chunk in single_result]
+                single_chunks: List[Chunk] = [Chunk.from_dict(chunk) for chunk in single_result]
                 return single_chunks
         except requests.exceptions.HTTPError as http_error:
             # Attempt to get more detailed error from API response if possible
@@ -134,6 +134,6 @@ class LateChunker(RecursiveChunker):
                 + "If the issue persists, please contact support at support@chonkie.ai."
             ) from error
     
-    def __call__(self, text: Optional[Union[str, List[str]]] = None, file: Optional[str] = None) -> Union[List[LateChunk], List[List[LateChunk]]]:
+    def __call__(self, text: Optional[Union[str, List[str]]] = None, file: Optional[str] = None) -> Union[List[Chunk], List[List[Chunk]]]:
         """Call the LateChunker to chunk text."""
         return self.chunk(text=text, file=file)

--- a/src/chonkie/cloud/chunker/recursive.py
+++ b/src/chonkie/cloud/chunker/recursive.py
@@ -6,7 +6,7 @@ from typing import Any, Callable, Dict, List, Optional, Union, cast
 import requests
 
 from chonkie.cloud.file import FileManager
-from chonkie.types import RecursiveChunk
+from chonkie.types import Chunk
 
 from .base import CloudChunker
 
@@ -109,16 +109,16 @@ class RecursiveChunker(CloudChunker):
         try:
             if isinstance(text, list):
                 batch_result: List[List[Dict]] = cast(List[List[Dict]], response.json())
-                batch_chunks: List[List[RecursiveChunk]] = []
+                batch_chunks: List[List[Chunk]] = []
                 for chunk_list in batch_result:
                     curr_chunks = []
                     for chunk in chunk_list:
-                        curr_chunks.append(RecursiveChunk.from_dict(chunk))
+                        curr_chunks.append(Chunk.from_dict(chunk))
                     batch_chunks.append(curr_chunks)
                 return batch_chunks
             else:
                 single_result: List[Dict] = cast(List[Dict], response.json())
-                single_chunks: List[RecursiveChunk] = [RecursiveChunk.from_dict(chunk) for chunk in single_result]
+                single_chunks: List[Chunk] = [Chunk.from_dict(chunk) for chunk in single_result]
                 return single_chunks
         except Exception as error:
             raise ValueError(

--- a/src/chonkie/cloud/chunker/sentence.py
+++ b/src/chonkie/cloud/chunker/sentence.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, List, Literal, Optional, Union, cast
 import requests
 
 from chonkie.cloud.file import FileManager
-from chonkie.types import SentenceChunk
+from chonkie.types import Chunk
 
 from .base import CloudChunker
 
@@ -74,7 +74,7 @@ class SentenceChunker(CloudChunker):
         # Initialize the file manager to upload files if needed
         self.file_manager = FileManager(api_key=self.api_key)
 
-    def chunk(self, text: Optional[Union[str, List[str]]] = None, file: Optional[str] = None) -> Union[List[SentenceChunk], List[List[SentenceChunk]]]:
+    def chunk(self, text: Optional[Union[str, List[str]]] = None, file: Optional[str] = None) -> Union[List[Chunk], List[List[Chunk]]]:
         """Chunk the text or file via sentence boundaries."""
         # Define the payload for the request
         payload: Dict[str, Any]
@@ -120,16 +120,16 @@ class SentenceChunker(CloudChunker):
         try:
             if isinstance(text, list):
                 batch_result: List[List[Dict]] = cast(List[List[Dict]], response.json())
-                batch_chunks: List[List[SentenceChunk]] = []
+                batch_chunks: List[List[Chunk]] = []
                 for chunk_list in batch_result:
-                    curr_chunks: List[SentenceChunk] = []
+                    curr_chunks: List[Chunk] = []
                     for chunk in chunk_list:
-                        curr_chunks.append(SentenceChunk.from_dict(chunk))
+                        curr_chunks.append(Chunk.from_dict(chunk))
                     batch_chunks.append(curr_chunks)
                 return batch_chunks
             else:
                 single_result: List[Dict] = cast(List[Dict], response.json())
-                single_chunks: List[SentenceChunk] = [SentenceChunk.from_dict(chunk) for chunk in single_result]
+                single_chunks: List[Chunk] = [Chunk.from_dict(chunk) for chunk in single_result]
                 return single_chunks
         except Exception as error:
             raise ValueError(
@@ -138,6 +138,6 @@ class SentenceChunker(CloudChunker):
                 + "If the issue persists, please contact support at support@chonkie.ai."
             ) from error
 
-    def __call__(self, text: Optional[Union[str, List[str]]] = None, file: Optional[str] = None) -> Union[List[SentenceChunk], List[List[SentenceChunk]]]:
+    def __call__(self, text: Optional[Union[str, List[str]]] = None, file: Optional[str] = None) -> Union[List[Chunk], List[List[Chunk]]]:
         """Call the SentenceChunker."""
         return self.chunk(text=text, file=file)

--- a/src/chonkie/experimental/code.py
+++ b/src/chonkie/experimental/code.py
@@ -7,7 +7,7 @@ import warnings
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from chonkie.chunker.base import BaseChunker
-from chonkie.types.base import Chunk
+from chonkie.types import Chunk
 from chonkie.types.code import SplitRule
 
 from .code_registry import CodeLanguageRegistry

--- a/src/chonkie/legacy/sdpm.py
+++ b/src/chonkie/legacy/sdpm.py
@@ -14,7 +14,8 @@ from typing import Any, Dict, List, Literal, Optional, Union
 
 from chonkie.embeddings import BaseEmbeddings
 from chonkie.legacy.semantic import SemanticChunker
-from chonkie.types import SemanticChunk, Sentence
+from chonkie.types import Sentence
+from chonkie.types.semantic import SemanticChunk
 from chonkie.utils import Hubbie
 
 

--- a/src/chonkie/types/__init__.py
+++ b/src/chonkie/types/__init__.py
@@ -2,7 +2,6 @@
 
 from .base import Chunk, Context
 from .code import LanguageConfig, MergeRule, SplitRule
-from .late import LateChunk
 from .recursive import RecursiveLevel, RecursiveRules
 from .semantic import SemanticSentence
 from .sentence import Sentence
@@ -14,7 +13,6 @@ __all__ = [
     "RecursiveRules",
     "Sentence",
     "SemanticSentence",
-    "LateChunk",
     "LanguageConfig",
     "MergeRule",
     "SplitRule",

--- a/src/chonkie/types/__init__.py
+++ b/src/chonkie/types/__init__.py
@@ -1,10 +1,10 @@
 """Module for chunkers."""
 
 from .base import Chunk, Context
-from .code import CodeChunk, LanguageConfig, MergeRule, SplitRule
+from .code import LanguageConfig, MergeRule, SplitRule
 from .late import LateChunk
 from .recursive import RecursiveLevel, RecursiveRules
-from .semantic import SemanticChunk, SemanticSentence
+from .semantic import SemanticSentence
 from .sentence import Sentence
 
 __all__ = [
@@ -13,11 +13,9 @@ __all__ = [
     "RecursiveLevel",
     "RecursiveRules",
     "Sentence",
-    "SemanticChunk",
     "SemanticSentence",
     "LateChunk",
     "LanguageConfig",
     "MergeRule",
     "SplitRule",
-    "CodeChunk",
 ]

--- a/src/chonkie/types/__init__.py
+++ b/src/chonkie/types/__init__.py
@@ -3,14 +3,13 @@
 from .base import Chunk, Context
 from .code import CodeChunk, LanguageConfig, MergeRule, SplitRule
 from .late import LateChunk
-from .recursive import RecursiveChunk, RecursiveLevel, RecursiveRules
+from .recursive import RecursiveLevel, RecursiveRules
 from .semantic import SemanticChunk, SemanticSentence
 from .sentence import Sentence
 
 __all__ = [
     "Chunk",
     "Context",
-    "RecursiveChunk",
     "RecursiveLevel",
     "RecursiveRules",
     "Sentence",

--- a/src/chonkie/types/__init__.py
+++ b/src/chonkie/types/__init__.py
@@ -5,7 +5,7 @@ from .code import CodeChunk, LanguageConfig, MergeRule, SplitRule
 from .late import LateChunk
 from .recursive import RecursiveChunk, RecursiveLevel, RecursiveRules
 from .semantic import SemanticChunk, SemanticSentence
-from .sentence import Sentence, SentenceChunk
+from .sentence import Sentence
 
 __all__ = [
     "Chunk",
@@ -14,7 +14,6 @@ __all__ = [
     "RecursiveLevel",
     "RecursiveRules",
     "Sentence",
-    "SentenceChunk",
     "SemanticChunk",
     "SemanticSentence",
     "LateChunk",

--- a/src/chonkie/types/late.py
+++ b/src/chonkie/types/late.py
@@ -3,14 +3,14 @@
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
-from .recursive import RecursiveChunk
+from .base import Chunk
 
 if TYPE_CHECKING:
     import numpy as np
 
 
 @dataclass
-class LateChunk(RecursiveChunk):
+class LateChunk(Chunk):
     """Class to represent the late chunk.
 
     Attributes:

--- a/src/chonkie/types/recursive.py
+++ b/src/chonkie/types/recursive.py
@@ -3,8 +3,6 @@
 import re
 from dataclasses import dataclass
 from typing import Dict, Iterator, List, Literal, Optional, Union
-
-from chonkie.types.base import Chunk
 from chonkie.utils import Hubbie
 
 
@@ -220,30 +218,3 @@ class RecursiveRules:
         recipe = hub.get_recipe(name, lang, path) 
         return cls.from_dict(recipe["recipe"]["recursive_rules"])
 
-@dataclass
-class RecursiveChunk(Chunk):
-    """Class to represent recursive chunks.
-
-    Attributes:
-        level (Optional[int]): The level of recursion for the chunk, if any.
-
-    """
-
-    level: Optional[int] = None
-
-    def __repr__(self) -> str:
-        """Return a string representation of the RecursiveChunk."""
-        return (
-            f"RecursiveChunk(text={self.text}, start_index={self.start_index}, "
-            f"end_index={self.end_index}, token_count={self.token_count}, "
-            f"level={self.level})"
-        )
-
-    def to_dict(self) -> Dict:
-        """Return the RecursiveChunk as a dictionary."""
-        return self.__dict__.copy()
-
-    @classmethod
-    def from_dict(cls, data: Dict) -> "RecursiveChunk":
-        """Create a RecursiveChunk object from a dictionary."""
-        return cls(**data)

--- a/src/chonkie/types/semantic.py
+++ b/src/chonkie/types/semantic.py
@@ -3,7 +3,8 @@
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
-from chonkie.types.sentence import Sentence, SentenceChunk
+from chonkie.types.base import Chunk
+from chonkie.types.sentence import Sentence
 
 if TYPE_CHECKING:
     import numpy as np
@@ -71,7 +72,7 @@ class SemanticSentence(Sentence):
 
 
 @dataclass
-class SemanticChunk(SentenceChunk):
+class SemanticChunk(Chunk):
     """SemanticChunk dataclass representing a semantic chunk with metadata.
 
     Attributes:
@@ -83,7 +84,7 @@ class SemanticChunk(SentenceChunk):
 
     """
 
-    sentences: List[SemanticSentence] = field(default_factory=list)  # type: ignore[assignment]
+    sentences: List[SemanticSentence] = field(default_factory=list)
 
     def to_dict(self) -> dict:
         """Return the SemanticChunk as a dictionary."""

--- a/src/chonkie/types/semantic.py
+++ b/src/chonkie/types/semantic.py
@@ -3,8 +3,8 @@
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
-from chonkie.types.base import Chunk
-from chonkie.types.sentence import Sentence
+from .base import Chunk
+from .sentence import Sentence
 
 if TYPE_CHECKING:
     import numpy as np

--- a/src/chonkie/types/sentence.py
+++ b/src/chonkie/types/sentence.py
@@ -1,9 +1,7 @@
 """Custom types for Sentence Chunking."""
 
-from dataclasses import dataclass, field
-from typing import Dict, List, Union
-
-from chonkie.types.base import Chunk
+from dataclasses import dataclass
+from typing import Dict, Union
 
 
 @dataclass
@@ -63,42 +61,3 @@ class Sentence:
         )
 
 
-@dataclass
-class SentenceChunk(Chunk):
-    """Class to represent sentence chunks.
-
-    Attributes:
-        text (str): The text of the chunk.
-        start_index (int): The starting index of the chunk in the original text.
-        end_index (int): The ending index of the chunk in the original text.
-        token_count (int): The number of tokens in the chunk.
-        sentences (list[Sentence]): List of sentences in the chunk.
-
-    """
-
-    sentences: List[Sentence] = field(default_factory=list)
-
-    def __repr__(self) -> str:
-        """Return a string representation of the SentenceChunk."""
-        return (
-            f"SentenceChunk(text={self.text}, start_index={self.start_index}, "
-            f"end_index={self.end_index}, token_count={self.token_count}, "
-            f"sentences={self.sentences})"
-        )
-
-    def to_dict(self) -> Dict:
-        """Return the SentenceChunk as a dictionary."""
-        result = super().to_dict()
-        result["sentences"] = [sentence.to_dict() for sentence in self.sentences]
-        return result
-
-    @classmethod
-    def from_dict(cls, data: dict) -> "SentenceChunk":
-        """Create a SentenceChunk from dictionary."""
-        sentences_dict = data.pop("sentences") if "sentences" in data else None
-        sentences = (
-            [Sentence.from_dict(sentence) for sentence in sentences_dict]
-            if sentences_dict is not None
-            else []
-        )
-        return cls(**data, sentences=sentences)

--- a/tests/chunkers/test_code_chunker.py
+++ b/tests/chunkers/test_code_chunker.py
@@ -2,7 +2,7 @@
 import pytest
 
 from chonkie import CodeChunker
-from chonkie.types.code import CodeChunk
+from chonkie.types import Chunk
 
 
 @pytest.fixture
@@ -64,12 +64,12 @@ def test_code_chunker_chunking_python(python_code: str) -> None:
 
     assert isinstance(chunks, list)
     assert len(chunks) > 0
-    assert all(isinstance(chunk, CodeChunk) for chunk in chunks)
+    assert all(isinstance(chunk, Chunk) for chunk in chunks)
     assert all(chunk.text is not None for chunk in chunks)
     assert all(chunk.start_index is not None for chunk in chunks)
     assert all(chunk.end_index is not None for chunk in chunks)
     assert all(chunk.token_count is not None for chunk in chunks)
-    assert all(chunk.nodes is not None for chunk in chunks)
+    # Note: nodes attribute is no longer part of base Chunk
 
 
 def test_code_chunker_reconstruction_python(python_code: str) -> None:
@@ -104,12 +104,12 @@ def test_code_chunker_indices_python(python_code: str) -> None:
 
 
 def test_code_chunker_return_type_chunks(python_code: str) -> None:
-    """Test that chunker returns CodeChunk objects by default."""
+    """Test that chunker returns Chunk objects."""
     chunker = CodeChunker(language="python", chunk_size=50)
     chunks = chunker.chunk(python_code)
     assert isinstance(chunks, list)
     assert len(chunks) > 0
-    assert all(isinstance(chunk, CodeChunk) for chunk in chunks)
+    assert all(isinstance(chunk, Chunk) for chunk in chunks)
     reconstructed_text = "".join(chunk.text for chunk in chunks)
     assert reconstructed_text == python_code
 
@@ -145,7 +145,7 @@ def test_code_chunker_chunking_javascript(js_code: str) -> None:
 
     assert isinstance(chunks, list)
     assert len(chunks) > 0
-    assert all(isinstance(chunk, CodeChunk) for chunk in chunks)
+    assert all(isinstance(chunk, Chunk) for chunk in chunks)
     reconstructed_text = "".join(chunk.text for chunk in chunks)
     assert reconstructed_text == js_code
 

--- a/tests/chunkers/test_late_chunker.py
+++ b/tests/chunkers/test_late_chunker.py
@@ -5,7 +5,7 @@ import pytest
 
 from chonkie import LateChunker
 from chonkie.embeddings import SentenceTransformerEmbeddings
-from chonkie.types import LateChunk, RecursiveLevel, RecursiveRules
+from chonkie.types import Chunk, RecursiveLevel, RecursiveRules
 
 
 @pytest.fixture
@@ -61,7 +61,7 @@ def test_late_chunker_chunk_basic(embedding_model: SentenceTransformerEmbeddings
 
     assert isinstance(chunks, list)
     assert len(chunks) > 0
-    assert all(isinstance(chunk, LateChunk) for chunk in chunks)
+    assert all(isinstance(chunk, Chunk) for chunk in chunks)
 
     # Check attributes of each chunk
     for chunk in chunks:
@@ -97,7 +97,7 @@ def test_late_chunker_chunk_short_text(embedding_model: SentenceTransformerEmbed
 
     assert len(chunks) == 1
     chunk = chunks[0]
-    assert isinstance(chunk, LateChunk)
+    assert isinstance(chunk, Chunk)
     assert chunk.text == text
     assert chunk.start_index == 0
     assert chunk.end_index == len(text)
@@ -106,7 +106,7 @@ def test_late_chunker_chunk_short_text(embedding_model: SentenceTransformerEmbed
     assert chunk.embedding.shape == (embedding_model.dimension,)
 
 
-def verify_chunk_indices(chunks: list[LateChunk], original_text: str) -> None:
+def verify_chunk_indices(chunks: list[Chunk], original_text: str) -> None:
     """Verify that chunk indices correctly map to the original text."""
     reconstructed_text = ""
     for i, chunk in enumerate(chunks):
@@ -133,7 +133,7 @@ def test_late_chunker_indices(embedding_model: SentenceTransformerEmbeddings, sa
 
 
 def test_late_chunk_repr(embedding_model: SentenceTransformerEmbeddings) -> None:
-    """Test the string representation of LateChunk."""
+    """Test the string representation of Chunk with embedding."""
     text = "This is a short text, definitely shorter than the chunk size."
     chunker = LateChunker(embedding_model=embedding_model, chunk_size=50)
     chunks = chunker.chunk(text)
@@ -142,7 +142,8 @@ def test_late_chunk_repr(embedding_model: SentenceTransformerEmbeddings) -> None
 
     chunk = chunks[0]
     representation = repr(chunk)
-    assert f"text={chunk.text}" in representation
+    assert "Chunk(" in representation
+    assert chunk.text in representation
     assert f"start_index={chunk.start_index}" in representation
     assert f"end_index={chunk.end_index}" in representation
     assert f"token_count={chunk.token_count}" in representation

--- a/tests/chunkers/test_recursive_chunker.py
+++ b/tests/chunkers/test_recursive_chunker.py
@@ -115,7 +115,7 @@ def test_recursive_chunker_chunking(
     assert all(chunk.text is not None for chunk in chunks)
     assert all(chunk.start_index is not None for chunk in chunks)
     assert all(chunk.end_index is not None for chunk in chunks)
-    assert all(chunk.level is not None for chunk in chunks)
+    # Note: level information is no longer directly accessible in the base Chunk type
 
 
 def test_recursive_chunker_token_count_default_rules(
@@ -405,7 +405,7 @@ def test_recursive_chunker_single_character(default_rules: RecursiveRules) -> No
     assert chunks[0].text == "a"
     assert chunks[0].start_index == 0
     assert chunks[0].end_index == 1
-    assert chunks[0].level == 0
+    # Note: level information is no longer directly accessible in the base Chunk type
 
 
 def test_recursive_chunker_min_characters_per_chunk(sample_text: str) -> None:

--- a/tests/chunkers/test_semantic_chunker.py
+++ b/tests/chunkers/test_semantic_chunker.py
@@ -6,7 +6,7 @@ import pytest
 
 from chonkie import SemanticChunker
 from chonkie.embeddings import BaseEmbeddings, Model2VecEmbeddings
-from chonkie.types.base import Chunk
+from chonkie.types import Chunk
 
 
 @pytest.fixture

--- a/tests/cloud/test_cloud_code_chunker.py
+++ b/tests/cloud/test_cloud_code_chunker.py
@@ -6,7 +6,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from chonkie.cloud import CodeChunker
-from chonkie.types import CodeChunk
+from chonkie.types import Chunk
 
 
 @pytest.fixture
@@ -182,7 +182,7 @@ def test_cloud_code_chunker_simple(mock_requests_get: Any, mock_requests_post: A
 
     # Check the result
     assert isinstance(result, list) and len(result) >= 1
-    assert isinstance(result[0], CodeChunk)
+    assert isinstance(result[0], Chunk)
     assert result[0].text
     assert result[0].token_count
     assert result[0].start_index is not None
@@ -212,7 +212,7 @@ def test_cloud_code_chunker_python_complex(mock_requests_get: Any, mock_requests
     # Check the result
     assert isinstance(result, list)
     assert len(result) > 1  # Should be split into multiple chunks
-    assert all(isinstance(item, CodeChunk) for item in result)
+    assert all(isinstance(item, Chunk) for item in result)
     assert all(isinstance(item.text, str) for item in result)
     assert all(isinstance(item.token_count, int) for item in result)
     assert all(isinstance(item.start_index, int) for item in result)
@@ -242,7 +242,7 @@ def test_cloud_code_chunker_javascript(mock_requests_get: Any, mock_requests_pos
     # Check the result
     assert isinstance(result, list)
     assert len(result) > 1  # Should be split into multiple chunks
-    assert all(isinstance(item, CodeChunk) for item in result)
+    assert all(isinstance(item, Chunk) for item in result)
     assert all(isinstance(item.text, str) for item in result)
     assert all(isinstance(item.token_count, int) for item in result)
 
@@ -270,7 +270,7 @@ def test_cloud_code_chunker_auto_language(mock_requests_get: Any, mock_requests_
     # Check the result
     assert isinstance(result, list)
     assert len(result) >= 1
-    assert all(isinstance(item, CodeChunk) for item in result)
+    assert all(isinstance(item, Chunk) for item in result)
     assert all(isinstance(item.text, str) for item in result)
 
     # Check that chunks can be reconstructed
@@ -298,7 +298,7 @@ def test_cloud_code_chunker_no_nodes_support(mock_requests_get: Any, mock_reques
 
     # Check the result - should not contain nodes since API doesn't support them
     assert isinstance(result, list) and len(result) >= 1
-    assert isinstance(result[0], CodeChunk)
+    assert isinstance(result[0], Chunk)
     assert result[0].text
     # API doesn't support tree-sitter nodes, so they shouldn't be in response
 
@@ -327,8 +327,8 @@ def test_cloud_code_chunker_batch(mock_requests_get: Any, mock_requests_post: An
     assert all(isinstance(item, list) for item in result), (
         f"Expected a list of lists, got {type(result)}"
     )
-    assert all(isinstance(chunk, CodeChunk) for batch in result for chunk in batch), (
-        "Expected lists of CodeChunks"
+    assert all(isinstance(chunk, Chunk) for batch in result for chunk in batch), (
+        "Expected lists of Chunks"
     )
     assert all(isinstance(chunk.text, str) for batch in result for chunk in batch), (
         "Expected chunks with text field"
@@ -458,7 +458,7 @@ def test_cloud_code_chunker_different_tokenizers(mock_requests_get: Any, mock_re
         
         assert isinstance(result, list)
         assert len(result) >= 1
-        assert all(isinstance(chunk, CodeChunk) for chunk in result)
+        assert all(isinstance(chunk, Chunk) for chunk in result)
         assert all(chunk.text for chunk in result)
 
 
@@ -482,6 +482,6 @@ def test_cloud_code_chunker_real_api(mock_requests_get: Any, mock_requests_post:
 
     # Check the result
     assert isinstance(result, list) and len(result) >= 1
-    assert isinstance(result[0], CodeChunk)
+    assert isinstance(result[0], Chunk)
     assert result[0].text
     assert result[0].token_count

--- a/tests/cloud/test_cloud_late_chunker.py
+++ b/tests/cloud/test_cloud_late_chunker.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from chonkie.cloud import LateChunker
-from chonkie.types import LateChunk
+from chonkie.types import Chunk
 
 
 @pytest.fixture
@@ -92,7 +92,7 @@ def test_cloud_late_chunker_single_text(mock_requests_get, mock_requests_post, m
     assert isinstance(result, list)
     if result: # API might return multiple chunks depending on its logic
         for chunk in result:
-            assert isinstance(chunk, LateChunk)
+            assert isinstance(chunk, Chunk)
             assert isinstance(chunk.text, str)
             assert isinstance(chunk.start_index, int)
             assert isinstance(chunk.end_index, int)
@@ -127,7 +127,7 @@ def test_cloud_late_chunker_batch_texts(mock_requests_get, mock_requests_post, m
         all_chunks = result[0]
         if all_chunks:
             for chunk in all_chunks: # Iterate through the inner list of chunks
-                assert isinstance(chunk, LateChunk)
+                assert isinstance(chunk, Chunk)
                 assert isinstance(chunk.text, str)
                 assert isinstance(chunk.start_index, int)
                 assert isinstance(chunk.end_index, int)
@@ -186,6 +186,6 @@ def test_cloud_late_chunker_real_api(mock_requests_get, mock_requests_post, mock
     assert isinstance(result, list)
     if result:
         for chunk in result:
-            assert isinstance(chunk, LateChunk)
+            assert isinstance(chunk, Chunk)
             assert isinstance(chunk.text, str)
             assert isinstance(chunk.token_count, int)

--- a/tests/cloud/test_cloud_sentence_chunker.py
+++ b/tests/cloud/test_cloud_sentence_chunker.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from chonkie.cloud import SentenceChunker
-from chonkie.types import SentenceChunk
+from chonkie.types import Chunk
 
 
 @pytest.fixture
@@ -143,7 +143,7 @@ def test_cloud_sentence_chunker_simple(mock_requests_get, mock_requests_post, mo
     result = sentence_chunker(text)
 
     # Check the result
-    assert isinstance(result, list) and isinstance(result[0], SentenceChunk) and len(result) == 1
+    assert isinstance(result, list) and isinstance(result[0], Chunk) and len(result) == 1
     assert result[0].text == "Hello, world!"
     assert result[0].token_count == 2  # Based on simple word split
     assert result[0].start_index == 0
@@ -192,7 +192,7 @@ def test_cloud_sentence_chunker_multiple_sentences(mock_requests_get, mock_reque
     # Check the result
     assert len(result) > 1
     assert isinstance(result, list)
-    assert all(isinstance(item, SentenceChunk) for item in result)
+    assert all(isinstance(item, Chunk) for item in result)
     assert all(isinstance(item.text, str) for item in result)
     assert all(isinstance(item.token_count, int) for item in result)
     assert all(isinstance(item.start_index, int) for item in result)
@@ -221,7 +221,7 @@ def test_cloud_sentence_chunker_batch(mock_requests_get, mock_requests_post, moc
     assert len(result) == len(texts)
     assert isinstance(result, list)
     assert all(isinstance(item, list) for item in result)
-    assert all(isinstance(item, SentenceChunk) for item in result[0])
+    assert all(isinstance(item, Chunk) for item in result[0])
     assert all(isinstance(item.text, str) for item in result[0])
     assert all(isinstance(item.token_count, int) for item in result[0])
     assert all(isinstance(item.start_index, int) for item in result[0])

--- a/tests/porters/test_datasets_porter.py
+++ b/tests/porters/test_datasets_porter.py
@@ -58,8 +58,8 @@ def test_export_empty_chunks():  # noqa
 def test_dataset_structure_and_content(sample_chunks):  # noqa
     porter = DatasetsPorter()
     ds = porter.export(sample_chunks, save_to_disk=False)
-    # Check column names
-    expected_columns = {"text", "start_index", "end_index", "token_count", "context"}
+    # Check column names - now includes embedding field
+    expected_columns = {"text", "start_index", "end_index", "token_count", "context", "embedding"}
     assert set(ds.column_names) == expected_columns
     # Check content
     for i, chunk in enumerate(sample_chunks):

--- a/tests/porters/test_datasets_porter.py
+++ b/tests/porters/test_datasets_porter.py
@@ -9,7 +9,7 @@ import pytest
 from datasets import Dataset
 
 from chonkie.friends.porters.datasets import DatasetsPorter
-from chonkie.types.base import Chunk
+from chonkie.types import Chunk
 
 
 @pytest.fixture

--- a/tests/refinery/test_embedding_refinery.py
+++ b/tests/refinery/test_embedding_refinery.py
@@ -123,18 +123,20 @@ def test_embeddings_refinery_is_available(mock_embeddings: MockEmbeddings) -> No
 def test_embeddings_refinery_refine_basic(mock_embeddings: MockEmbeddings, sample_chunks: list[Chunk]) -> None:
     """Test basic refine functionality."""
     refinery = EmbeddingsRefinery(mock_embeddings)
-    
-    # Ensure chunks don't have embeddings initially
+
+    # Ensure chunks don't have embeddings initially (should be None)
     for chunk in sample_chunks:
-        assert not hasattr(chunk, 'embedding')
-    
+        assert hasattr(chunk, 'embedding')  # attribute exists
+        assert chunk.embedding is None  # but is None initially
+
     refined_chunks = refinery.refine(sample_chunks)
-    
+
     # Check that embeddings were added
     assert len(refined_chunks) == 3
     for chunk in refined_chunks:
         assert hasattr(chunk, 'embedding')
         import numpy as np
+        assert chunk.embedding is not None  # Now should have a value
         assert isinstance(chunk.embedding, np.ndarray)
         assert chunk.embedding.shape == (128,)  # Mock dimension
         assert chunk.embedding.dtype == np.float32

--- a/tests/refinery/test_embedding_refinery.py
+++ b/tests/refinery/test_embedding_refinery.py
@@ -228,15 +228,13 @@ def test_embeddings_refinery_embed_batch_called_correctly(mock_embeddings: MockE
 
 def test_embeddings_refinery_with_different_chunk_types() -> None:
     """Test refinery with different chunk types."""
-    from chonkie.types import RecursiveChunk
-
     mock_embeddings = MockEmbeddings()
     refinery = EmbeddingsRefinery(mock_embeddings)
 
     # Mix of different chunk types
     chunks = [
         Chunk(text="Regular chunk", start_index=0, end_index=12, token_count=2),
-        RecursiveChunk(text="Recursive chunk", start_index=13, end_index=27, token_count=2, level=1),
+        Chunk(text="Recursive chunk", start_index=13, end_index=27, token_count=2),
         Chunk(text="Sentence chunk", start_index=28, end_index=41, token_count=2),
     ]
     

--- a/tests/refinery/test_embedding_refinery.py
+++ b/tests/refinery/test_embedding_refinery.py
@@ -228,16 +228,16 @@ def test_embeddings_refinery_embed_batch_called_correctly(mock_embeddings: MockE
 
 def test_embeddings_refinery_with_different_chunk_types() -> None:
     """Test refinery with different chunk types."""
-    from chonkie.types import RecursiveChunk, SentenceChunk
-    
+    from chonkie.types import RecursiveChunk
+
     mock_embeddings = MockEmbeddings()
     refinery = EmbeddingsRefinery(mock_embeddings)
-    
+
     # Mix of different chunk types
     chunks = [
         Chunk(text="Regular chunk", start_index=0, end_index=12, token_count=2),
         RecursiveChunk(text="Recursive chunk", start_index=13, end_index=27, token_count=2, level=1),
-        SentenceChunk(text="Sentence chunk", start_index=28, end_index=41, token_count=2),
+        Chunk(text="Sentence chunk", start_index=28, end_index=41, token_count=2),
     ]
     
     refined_chunks = refinery.refine(chunks)

--- a/tests/types/test_base.py
+++ b/tests/types/test_base.py
@@ -87,3 +87,135 @@ def test_chunk_serialization():
     assert chunk.text == restored.text
     assert chunk.token_count == restored.token_count
     assert chunk.context.text == restored.context.text
+
+
+def test_chunk_with_embedding():
+    """Test Chunk with embedding attribute."""
+    # Test initialization without embedding
+    chunk1 = Chunk(text="test", start_index=0, end_index=4, token_count=1)
+    assert chunk1.embedding is None
+
+    # Test initialization with list embedding
+    chunk2 = Chunk(
+        text="test",
+        start_index=0,
+        end_index=4,
+        token_count=1,
+        embedding=[0.1, 0.2, 0.3]
+    )
+    assert chunk2.embedding == [0.1, 0.2, 0.3]
+
+
+@pytest.mark.skipif(not NUMPY_AVAILABLE, reason="NumPy not available")
+def test_chunk_with_numpy_embedding():
+    """Test Chunk with numpy array embedding."""
+    import numpy as np
+
+    embedding = np.array([0.1, 0.2, 0.3, 0.4, 0.5])
+    chunk = Chunk(
+        text="test",
+        start_index=0,
+        end_index=4,
+        token_count=1,
+        embedding=embedding
+    )
+    assert chunk.embedding is not None
+    assert isinstance(chunk.embedding, np.ndarray)
+    assert len(chunk.embedding) == 5
+
+
+def test_chunk_embedding_repr():
+    """Test Chunk __repr__ with embedding."""
+    # Test without embedding
+    chunk1 = Chunk(text="test", start_index=0, end_index=4, token_count=1)
+    repr1 = repr(chunk1)
+    assert "embedding" not in repr1
+
+    # Test with short list embedding
+    chunk2 = Chunk(
+        text="test",
+        start_index=0,
+        end_index=4,
+        token_count=1,
+        embedding=[0.1, 0.2, 0.3]
+    )
+    repr2 = repr(chunk2)
+    assert "embedding" in repr2
+    assert "0.1000" in repr2
+    assert "..." not in repr2  # Should show all values for short embedding
+
+    # Test with long list embedding
+    chunk3 = Chunk(
+        text="test",
+        start_index=0,
+        end_index=4,
+        token_count=1,
+        embedding=[i * 0.1 for i in range(100)]
+    )
+    repr3 = repr(chunk3)
+    assert "embedding" in repr3
+    assert "..." in repr3  # Should truncate long embedding
+    assert "0.0000" in repr3  # First value
+    assert "9.8000" in repr3  # Second to last value
+
+
+@pytest.mark.skipif(not NUMPY_AVAILABLE, reason="NumPy not available")
+def test_chunk_numpy_embedding_repr():
+    """Test Chunk __repr__ with numpy embedding shows shape."""
+    import numpy as np
+
+    embedding = np.random.randn(768)  # Typical embedding size
+    chunk = Chunk(
+        text="test",
+        start_index=0,
+        end_index=4,
+        token_count=1,
+        embedding=embedding
+    )
+    repr_str = repr(chunk)
+    assert "embedding" in repr_str
+    assert "..." in repr_str  # Should truncate
+    assert "shape=(768,)" in repr_str  # Should show shape
+
+
+def test_chunk_embedding_serialization():
+    """Test Chunk serialization with embedding."""
+    # Test with list embedding
+    chunk1 = Chunk(
+        text="test",
+        start_index=0,
+        end_index=4,
+        token_count=1,
+        embedding=[0.1, 0.2, 0.3]
+    )
+    dict1 = chunk1.to_dict()
+    assert "embedding" in dict1
+    assert dict1["embedding"] == [0.1, 0.2, 0.3]
+
+    restored1 = Chunk.from_dict(dict1)
+    assert restored1.embedding == [0.1, 0.2, 0.3]
+
+
+@pytest.mark.skipif(not NUMPY_AVAILABLE, reason="NumPy not available")
+def test_chunk_numpy_embedding_serialization():
+    """Test Chunk serialization with numpy embedding."""
+    import numpy as np
+
+    embedding = np.array([0.1, 0.2, 0.3, 0.4, 0.5])
+    chunk = Chunk(
+        text="test",
+        start_index=0,
+        end_index=4,
+        token_count=1,
+        embedding=embedding
+    )
+
+    # to_dict should convert numpy to list
+    dict_repr = chunk.to_dict()
+    assert "embedding" in dict_repr
+    assert isinstance(dict_repr["embedding"], list)
+    assert dict_repr["embedding"] == [0.1, 0.2, 0.3, 0.4, 0.5]
+
+    # from_dict keeps as list (numpy conversion happens elsewhere if needed)
+    restored = Chunk.from_dict(dict_repr)
+    assert restored.embedding == [0.1, 0.2, 0.3, 0.4, 0.5]

--- a/tests/types/test_base.py
+++ b/tests/types/test_base.py
@@ -6,6 +6,12 @@ import pytest
 
 from chonkie import Chunk, Context
 
+try:
+    import numpy as np
+    NUMPY_AVAILABLE = True
+except ImportError:
+    NUMPY_AVAILABLE = False
+
 
 def test_context_init():
     """Test Context initialization."""

--- a/tests/types/test_recursive.py
+++ b/tests/types/test_recursive.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from chonkie import RecursiveChunk, RecursiveLevel, RecursiveRules
+from chonkie import RecursiveLevel, RecursiveRules
 
 
 def test_recursive_level_init() -> None:
@@ -70,33 +70,6 @@ def test_recursive_rules_serialization() -> None:
     assert all(isinstance(level, RecursiveLevel) for level in reconstructed.levels)
 
 
-# RecursiveChunk Tests
-def test_recursive_chunk_init() -> None:
-    """Test RecursiveChunk initialization."""
-    chunk = RecursiveChunk(
-        text="test chunk",
-        start_index=0,
-        end_index=10,
-        token_count=2,
-        level=1,
-    )
-    assert chunk.text == "test chunk"
-    assert chunk.level == 1
-
-
-def test_recursive_chunk_serialization() -> None:
-    """Test RecursiveChunk serialization/deserialization."""
-    chunk = RecursiveChunk(
-        text="test chunk",
-        start_index=0,
-        end_index=10,
-        token_count=2,
-        level=1,
-    )
-    chunk_dict = chunk.to_dict()
-    reconstructed = RecursiveChunk.from_dict(chunk_dict)
-    assert reconstructed.level == 1
-    assert reconstructed.text == chunk.text
 
 def test_recursive_level_from_recipe() -> None:
     """Test RecursiveLevel from recipe."""

--- a/tests/types/test_sentence.py
+++ b/tests/types/test_sentence.py
@@ -1,8 +1,8 @@
-"""Unit tests for Sentence and SentenceChunk classes."""
+"""Unit tests for Sentence class."""
 
 import pytest
 
-from chonkie import Sentence, SentenceChunk
+from chonkie import Sentence
 
 
 def test_sentence_init():
@@ -56,38 +56,3 @@ def test_sentence_serialization():
     assert sentence.token_count == restored.token_count
 
 
-def test_sentence_chunk_init():
-    """Test SentenceChunk initialization."""
-    sentences = [
-        Sentence("First sentence.", 0, 14, 3),
-        Sentence("Second sentence.", 15, 30, 3),
-    ]
-    chunk = SentenceChunk(
-        text="Wall-E is a Pixar movie. Ratatouille is another one.",
-        start_index=0,
-        end_index=30,
-        token_count=6,
-        sentences=sentences,
-    )
-    assert chunk.text == "Wall-E is a Pixar movie. Ratatouille is another one."
-    assert len(chunk.sentences) == 2
-    assert all(isinstance(s, Sentence) for s in chunk.sentences)
-
-
-def test_sentence_chunk_serialization():
-    """Test SentenceChunk serialization/deserialization."""
-    sentences = [
-        Sentence("First sentence.", 0, 14, 3),
-        Sentence("Second sentence.", 15, 30, 3),
-    ]
-    chunk = SentenceChunk(
-        text="Wall-E is a Pixar movie. Ratatouille is another one.",
-        start_index=0,
-        end_index=30,
-        token_count=6,
-        sentences=sentences,
-    )
-    chunk_dict = chunk.to_dict()
-    restored = SentenceChunk.from_dict(chunk_dict)
-    assert len(restored.sentences) == 2
-    assert all(isinstance(s, Sentence) for s in restored.sentences)


### PR DESCRIPTION
This pull request introduces a major breaking change to the Chonkie Python SDK: all chunkers now return the unified base `Chunk` type instead of specialized chunk types. This streamlines the API, improves interoperability between chunkers and refineries, and introduces a new optional `embedding` attribute on the `Chunk` type. Documentation, type imports, and function signatures have been updated throughout the codebase and docs to reflect this change. The specialized chunk types remain available in a legacy module for backward compatibility.

**Core API and Type System Changes:**

* All chunkers (`SentenceChunker`, `RecursiveChunker`, `CodeChunker`, `LateChunker`, etc.) now return the base `Chunk` type rather than specialized types such as `SentenceChunk`, `RecursiveChunk`, `CodeChunk`, or `LateChunk`. The `Chunk` type includes a new optional `embedding` attribute for storing embedding vectors. [[1]](diffhunk://#diff-a64733bbe3aaff26a1365301d956150b2f54253f49d639f7cbaddd066221ac3bR9-R47) [[2]](diffhunk://#diff-44a557df57b150a7b71a0b691e66e501f00f8983cc9c66dee9309aaf738bd408L69-L80) [[3]](diffhunk://#diff-10846354259652bb75e491a4bbce39e3909b204c82e70145936f910655ad97a0L11-R11) [[4]](diffhunk://#diff-55afb1c1c6e6001a39e128592d27a02736a0621ebb4a360e69e5bd8fe6971ab3L14-R14) [[5]](diffhunk://#diff-55afb1c1c6e6001a39e128592d27a02736a0621ebb4a360e69e5bd8fe6971ab3L300-R300) [[6]](diffhunk://#diff-55afb1c1c6e6001a39e128592d27a02736a0621ebb4a360e69e5bd8fe6971ab3L309-R316) [[7]](diffhunk://#diff-b8d4de839dd57d649b54fd5627f9cb77749311ee5e9965e7038f2bbddaed7277L9-R9) [[8]](diffhunk://#diff-b8d4de839dd57d649b54fd5627f9cb77749311ee5e9965e7038f2bbddaed7277L132-R132) [[9]](diffhunk://#diff-b8d4de839dd57d649b54fd5627f9cb77749311ee5e9965e7038f2bbddaed7277L166-R171) [[10]](diffhunk://#diff-8bbe8a372641303a22785a4d84abd72a02d9cad7afe7d7055d0f9581cae268b7L13-R13) [[11]](diffhunk://#diff-8bbe8a372641303a22785a4d84abd72a02d9cad7afe7d7055d0f9581cae268b7L191-R192) [[12]](diffhunk://#diff-8bbe8a372641303a22785a4d84abd72a02d9cad7afe7d7055d0f9581cae268b7L204-L212) [[13]](diffhunk://#diff-8bbe8a372641303a22785a4d84abd72a02d9cad7afe7d7055d0f9581cae268b7L305-R304) [[14]](diffhunk://#diff-8bbe8a372641303a22785a4d84abd72a02d9cad7afe7d7055d0f9581cae268b7L342-R341) [[15]](diffhunk://#diff-8bbe8a372641303a22785a4d84abd72a02d9cad7afe7d7055d0f9581cae268b7L354-R353) [[16]](diffhunk://#diff-f8621e6d7d2b3c3d8fecdaf6ec442aefbd9acecf06764aed2d6953b6e995ee7cL14-R14) [[17]](diffhunk://#diff-f8621e6d7d2b3c3d8fecdaf6ec442aefbd9acecf06764aed2d6953b6e995ee7cL258-R258) [[18]](diffhunk://#diff-f8621e6d7d2b3c3d8fecdaf6ec442aefbd9acecf06764aed2d6953b6e995ee7cL275-R282)

**Documentation Updates:**

* All documentation and usage examples have been updated to reference the unified `Chunk` type, including migration notes and updated code samples. Specialized chunk attributes are marked as deprecated or removed from examples. [[1]](diffhunk://#diff-a64733bbe3aaff26a1365301d956150b2f54253f49d639f7cbaddd066221ac3bR9-R47) [[2]](diffhunk://#diff-e3393988b7656c2676e5bbaf72a626b33245422e7e494d0548a1b14816d8d9eeL76-R76) [[3]](diffhunk://#diff-e3393988b7656c2676e5bbaf72a626b33245422e7e494d0548a1b14816d8d9eeL129-R143) [[4]](diffhunk://#diff-67ba3507c0fd5d67270f39ba3c4b32b4af4086e71837a4c3a267505601a46941L133-R133) [[5]](diffhunk://#diff-26bb60fe128813cb5204e038bf8fe76b5866963681abcab3c6da93a9af838c3eL126-L135) [[6]](diffhunk://#diff-932896c49ff783a876a80462454a8c84f5f9da826386e02d958e3e04d1aa481aL169-L185) [[7]](diffhunk://#diff-f43a9e2f7da89777ca234fc2f236252b27a44652586c9514b243e81bf1b19114R22-R23) [[8]](diffhunk://#diff-f43a9e2f7da89777ca234fc2f236252b27a44652586c9514b243e81bf1b19114L131-R153) [[9]](diffhunk://#diff-f43a9e2f7da89777ca234fc2f236252b27a44652586c9514b243e81bf1b19114L252-R277) [[10]](diffhunk://#diff-f43a9e2f7da89777ca234fc2f236252b27a44652586c9514b243e81bf1b19114L279-R301) [[11]](diffhunk://#diff-f43a9e2f7da89777ca234fc2f236252b27a44652586c9514b243e81bf1b19114L1416-R1438)

**Backward Compatibility:**

* The specialized chunk types (`SentenceChunk`, `RecursiveChunk`, `CodeChunk`, etc.) are now deprecated but remain available in a legacy module for backward compatibility.

**Migration Guidance:**

* A migration guide is provided in the docs, detailing how to adapt code that previously relied on specialized chunk attributes to the new unified `Chunk` type. [[1]](diffhunk://#diff-a64733bbe3aaff26a1365301d956150b2f54253f49d639f7cbaddd066221ac3bR9-R47) [[2]](diffhunk://#diff-f43a9e2f7da89777ca234fc2f236252b27a44652586c9514b243e81bf1b19114L131-R153)

**Miscellaneous:**

* Internal and public APIs, as well as type imports and function signatures, have been updated to use the new `Chunk` type. [[1]](diffhunk://#diff-44a557df57b150a7b71a0b691e66e501f00f8983cc9c66dee9309aaf738bd408L69-L80) [[2]](diffhunk://#diff-10846354259652bb75e491a4bbce39e3909b204c82e70145936f910655ad97a0L11-R11) [[3]](diffhunk://#diff-55afb1c1c6e6001a39e128592d27a02736a0621ebb4a360e69e5bd8fe6971ab3L14-R14) [[4]](diffhunk://#diff-b8d4de839dd57d649b54fd5627f9cb77749311ee5e9965e7038f2bbddaed7277L9-R9) [[5]](diffhunk://#diff-8bbe8a372641303a22785a4d84abd72a02d9cad7afe7d7055d0f9581cae268b7L13-R13) [[6]](diffhunk://#diff-f8621e6d7d2b3c3d8fecdaf6ec442aefbd9acecf06764aed2d6953b6e995ee7cL14-R14)

These changes significantly simplify the Chonkie API, making it easier to chain and compose chunkers and refineries. Existing users should review the migration guide to update their code accordingly.