### PR TITLE
Update version to 1.3.0 in pyproject.toml and __init__.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "chonkie"
-version = "1.2.1"
+version = "1.3.0"
 description = "🦛 CHONK your texts with Chonkie ✨ - The no-nonsense chunking library"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/chonkie/__init__.py
+++ b/src/chonkie/__init__.py
@@ -83,6 +83,6 @@ from .utils import (
 )
 
 # This hippo grows with every release 🦛✨~
-__version__ = "1.2.1"
+__version__ = "1.3.0"
 __name__ = "chonkie"
 __author__ = "🦛 Chonkie Inc"


### PR DESCRIPTION
This pull request updates the version of the `chonkie` package from 1.2.1 to 1.3.0 in preparation for a new release.

- Version bump:
  * Updated the `version` field in `pyproject.toml` to `1.3.0`.
  * Updated the `__version__` attribute in `src/chonkie/__init__.py` to `1.3.0`.