### PR TITLE
Feat: Add support for wrapped `MarkdownImages` and filter empty text blocks in MarkdownChef

### DIFF
--- a/src/chonkie/chef/markdown.py
+++ b/src/chonkie/chef/markdown.py
@@ -97,7 +97,7 @@ class MarkdownChef(BaseChef):
     images: List[MarkdownImage] = []
 
     for match in self.image_pattern.finditer(markdown):
-        opening_bracket = match.group(1)  # '[' for wrapped images, None for regular
+        match.group(1)  # '[' for wrapped images, None for regular
         alt_text = match.group(2)         # Alt text
         image_src = match.group(3)        # Image URL
         link_url = match.group(4)         # Link URL (None if not wrapped)

--- a/src/chonkie/chef/markdown.py
+++ b/src/chonkie/chef/markdown.py
@@ -35,7 +35,7 @@ class MarkdownChef(BaseChef):
     self.tokenizer = tokenizer if isinstance(tokenizer, Tokenizer) else Tokenizer(tokenizer)
     self.code_pattern = re.compile(r"```([a-zA-Z0-9+\-_]*)\n?(.*?)\n?```", re.DOTALL)
     self.table_pattern = re.compile(r"(\|.*?\n\|[-: ]+\|.*?\n(?:\|.*?\n)*)")
-    self.image_pattern = re.compile(r"!\[([^\]]*)\]\(([^)]+)\)")
+    self.image_pattern = re.compile(r"(\[)?!\[([^\]]*)\]\(([^)]+)\)(?:\]\(([^)]+)\))?")
 
   def prepare_tables(self, markdown: str) -> List[MarkdownTable]:
     """Prepare the tables for the MarkdownDocument.
@@ -97,8 +97,10 @@ class MarkdownChef(BaseChef):
     images: List[MarkdownImage] = []
 
     for match in self.image_pattern.finditer(markdown):
-        alt_text = match.group(1)
-        image_src = match.group(2)
+        opening_bracket = match.group(1)  # '[' for wrapped images, None for regular
+        alt_text = match.group(2)         # Alt text
+        image_src = match.group(3)        # Image URL
+        link_url = match.group(4)         # Link URL (None if not wrapped)
 
         # Determine the key for the image
         if alt_text:
@@ -119,7 +121,13 @@ class MarkdownChef(BaseChef):
             key = f"{original_key}_{counter}"
             counter += 1
 
-        images.append(MarkdownImage(alias=key, content=image_src, start_index=match.start(), end_index=match.end()))
+        images.append(MarkdownImage(
+            alias=key,
+            content=image_src,
+            start_index=match.start(),
+            end_index=match.end(),
+            link=link_url
+        ))
 
     return images
 
@@ -168,8 +176,11 @@ class MarkdownChef(BaseChef):
       start_index = index[0]
       end_index = index[1]
       text = markdown[start_index:end_index]
-      token_count = self.tokenizer.count_tokens(text)
-      chunks.append(Chunk(text=text, start_index=start_index, end_index=end_index, token_count=token_count))
+
+      # Only create chunk if it contains meaningful content (not just whitespace)
+      if text.strip():
+        token_count = self.tokenizer.count_tokens(text)
+        chunks.append(Chunk(text=text, start_index=start_index, end_index=end_index, token_count=token_count))
 
     return chunks
 

--- a/src/chonkie/chef/markdown.py
+++ b/src/chonkie/chef/markdown.py
@@ -35,7 +35,7 @@ class MarkdownChef(BaseChef):
     self.tokenizer = tokenizer if isinstance(tokenizer, Tokenizer) else Tokenizer(tokenizer)
     self.code_pattern = re.compile(r"```([a-zA-Z0-9+\-_]*)\n?(.*?)\n?```", re.DOTALL)
     self.table_pattern = re.compile(r"(\|.*?\n\|[-: ]+\|.*?\n(?:\|.*?\n)*)")
-    self.image_pattern = re.compile(r"(\[)?!\[([^\]]*)\]\(([^)]+)\)(?:\]\(([^)]+)\))?")
+    self.image_pattern = re.compile(r"(\[)?!\[([^\]]*)\]\(([^)]+)\)(?(1)\]\(([^)]+)\)|)")
 
   def prepare_tables(self, markdown: str) -> List[MarkdownTable]:
     """Prepare the tables for the MarkdownDocument.
@@ -97,11 +97,9 @@ class MarkdownChef(BaseChef):
     images: List[MarkdownImage] = []
 
     for match in self.image_pattern.finditer(markdown):
-        match.group(1)  # '[' for wrapped images, None for regular
-        alt_text = match.group(2)         # Alt text
-        image_src = match.group(3)        # Image URL
-        link_url = match.group(4)         # Link URL (None if not wrapped)
-
+        # Extract the match groups
+        _, alt_text, image_src, link_url = match.groups()
+        
         # Determine the key for the image
         if alt_text:
             key = alt_text

--- a/src/chonkie/types/markdown.py
+++ b/src/chonkie/types/markdown.py
@@ -31,6 +31,7 @@ class MarkdownImage:
     content: str = field(default_factory=str)
     start_index: int = field(default_factory=int)
     end_index: int = field(default_factory=int)
+    link: Optional[str] = field(default=None)
 
 @dataclass
 class MarkdownDocument(Document):


### PR DESCRIPTION
This pull request enhances the Markdown image extraction logic and improves chunk extraction robustness in the `src/chonkie/chef/markdown.py` module. The main improvements are support for images that are also links, capturing associated link URLs, and ensuring that only meaningful content is chunked. Additionally, the `MarkdownImage` data class is updated to store link information.

**Markdown image extraction improvements:**

* Updated the image regex in `__init__` to support Markdown images that are also links, allowing extraction of both standalone images and images wrapped in links.
* Modified `extract_images` to extract the image's alt text, source, and (if present) the link URL, and to pass the link URL to the `MarkdownImage` object. [[1]](diffhunk://#diff-12ac256a63bef80ddf47cf38111a93d84b9b7817c5da1881121dc813c735ca39L100-R101) [[2]](diffhunk://#diff-12ac256a63bef80ddf47cf38111a93d84b9b7817c5da1881121dc813c735ca39L122-R128)
* Added a `link` field to the `MarkdownImage` data class to store the associated URL if the image is also a link.

**Chunk extraction improvements:**

* Updated `extract_chunks` to only create chunks for non-whitespace content, preventing empty or meaningless chunks from being generated.