### PR TITLE
Feat: add search method for turbopuffer handshake

### DIFF
--- a/docs/python-sdk/handshakes/tubropuffer-handshake.mdx
+++ b/docs/python-sdk/handshakes/tubropuffer-handshake.mdx
@@ -56,6 +56,62 @@ chunks = chunker("Chonkie chunks, turbopuffer puffs!")
 handshake.write(chunks)
 ```
 
+### Searching Chunks in Turbopuffer
+
+You can retrieve the most similar chunks from your Turbopuffer namespace using the `search` method:
+<CodeGroup>
+```python search using a query
+from chonkie import TurbopufferHandshake
+
+# Initialize the handshake
+handshake = TurbopufferHandshake(namespace_name="my_documents")
+
+# Search for similar chunks
+results = handshake.search(query="puffy chonks", limit=2)
+for result in results:
+    print(result["score"], result["text"])
+```
+
+```python search using embedding
+from chonkie import TurbopufferHandshake
+
+# Initialize the handshake
+handshake = TurbopufferHandshake(namespace_name="my_documents")
+
+# Generate an embedding
+embedding = handshake.embedding_model.embed("puffy chonks").tolist()
+
+# Search using the embedding
+results = handshake.search(embedding=embedding, limit=2)
+for result in results:
+    print(result["score"], result["text"])
+```
+
+```python search using chonkie chunks
+from chonkie import TurbopufferHandshake, SemanticChunker
+
+# Initialize the handshake
+handshake = TurbopufferHandshake(namespace_name="my_documents")
+
+# Create some chunks
+chunker = SemanticChunker()
+chunks = chunker.chunk("Chonkie chunks, turbopuffer puffs!")
+
+# Generate an embedding from a chunk's text to use for the search
+if chunks:
+    search_embedding = handshake.embedding_model.embed(chunks.text).tolist()
+
+    # Search the handshake using the generated embedding
+    results = handshake.search(
+        embedding=search_embedding,
+        limit=2,
+    )
+    for result in results:
+        print(result["score"], result["text"])
+```
+</CodeGroup>
+
+
 ## Parameters
 
 <ParamField


### PR DESCRIPTION
**Description:**

This PR adds the `search` method to the `TurbopufferHandshake`, enabling users to perform vector similarity searches directly on their Turbopuffer namespaces. This enhancement aligns the Turbopuffer integration with other vector database handshakes in the library, providing a consistent and powerful API for retrieval tasks.

The implementation handles both text queries (by generating an embedding) and direct embedding vectors.

### Changes Made

-   **`src/chonkie/handshakes/turbopuffer.py`**:
    -   Implemented the `search()` method within the `TurbopufferHandshake` class.
    -   The method utilizes the `namespace.query()` function from the `turbopuffer` Python SDK.
    -   It correctly formats the query results, converting Turbopuffer's `distance` metric into a `score` for consistency with other handshakes.
-   **`docs/python-sdk/handshakes/tubropuffer-handshake.mdx`**:
    -   Added a new "Searching Chunks in Turbopuffer" section to the documentation.
    -   Provided three clear code examples for searching with a text query, a raw embedding, and an embedding generated from a `Chonkie` chunk.

### Related Issue
#248 