### PR TITLE
Feat: Add `chunk_document` to the `TableChunker`

### DIFF
--- a/src/chonkie/chunker/table.py
+++ b/src/chonkie/chunker/table.py
@@ -6,7 +6,7 @@ from typing import Any, Callable, List, Union
 from typing_extensions import Tuple
 
 from chonkie.chunker.base import BaseChunker
-from chonkie.types import Chunk
+from chonkie.types import Chunk, Document, MarkdownDocument
 
 
 class TableChunker(BaseChunker):
@@ -118,7 +118,21 @@ class TableChunker(BaseChunker):
             chunks.append(chunk)
         
         return chunks
-
+    
+    def chunk_document(self, document: Document) -> Document:
+        """Chunk a document."""
+        if isinstance(document, MarkdownDocument) and document.tables:
+            for table in document.tables:
+                chunks = self.chunk(table.content)
+                for chunk in chunks:
+                    chunk.start_index = table.start_index + chunk.start_index
+                    chunk.end_index = table.start_index + chunk.end_index
+                document.chunks.extend(chunks)
+            document.chunks.sort(key=lambda x: x.start_index)
+        else: 
+            document.chunks = self.chunk(document.content)
+        return document
+    
     def __repr__(self) -> str:
         """Return a string representation of the TableChunker."""
         return f"TableChunker(tokenizer={self.tokenizer}, chunk_size={self.chunk_size})"


### PR DESCRIPTION
This pull request enhances the `TableChunker` class to support chunking entire `Document` objects, with special handling for `MarkdownDocument` instances that contain tables. The main focus is on improving the flexibility and integration of the chunking process with document types.

**Enhancements to document chunking:**

* Added a `chunk_document` method to `TableChunker` that processes a `Document` object, handling `MarkdownDocument` tables by chunking each table and adjusting chunk indices accordingly. For other document types, it chunks the entire content. (`src/chonkie/chunker/table.py`)
* Updated imports in `src/chonkie/chunker/table.py` to include `Document` and `MarkdownDocument` for the new method.