### PR TITLE
Fix: Deprecate `Py3.9` and add support for `Py3.13`!

### DIFF
--- a/.github/workflows/python-test-pr-main.yml
+++ b/.github/workflows/python-test-pr-main.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/python-test-pr.yml
+++ b/.github/workflows/python-test-pr.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ name = "chonkie"
 version = "1.3.1"
 description = "🦛 CHONK your texts with Chonkie ✨ - The no-nonsense chunking library"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = { file = "LICENSE" }
 keywords = [
     "chunking",
@@ -34,7 +34,6 @@ maintainers = [
 classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
Reasons: 

- End of life for Python 3.9 is in October 2025. 
- Downloads for chonkie with python 3.9 are about 0. Most people don't use it in python 3.9. 
- Can update some things with python 3.10 being the base like typing support as `X | Y` instead of `Union[X, Y]`