### PR TITLE
Docs: Add Pipelines + FileFetcher Documentation 

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -32,7 +32,8 @@
             "group": "Getting Started",
             "pages": [
               "oss/quick-start",
-              "oss/installation"
+              "oss/installation",
+              "oss/pipelines"
             ]
           },
           {
@@ -42,6 +43,13 @@
               "oss/chefs/tablechef",
               "oss/chefs/textchef",
               "oss/chefs/markdownchef"
+            ]
+          },
+          {
+            "group": "Fetchers",
+            "pages": [
+              "oss/fetchers/overview",
+              "oss/fetchers/file-fetcher"
             ]
           },
           {

--- a/docs/oss/fetchers/file-fetcher.mdx
+++ b/docs/oss/fetchers/file-fetcher.mdx
@@ -1,0 +1,155 @@
+---
+title: FileFetcher
+sidebarTitle: FileFetcher
+icon: "file"
+iconType: "solid"
+description: Fetch files from local filesystem for pipeline processing
+---
+
+The `FileFetcher` retrieves files from your local filesystem. It supports two modes: fetching a single file or fetching multiple files from a directory with optional extension filtering.
+
+## Installation
+
+FileFetcher is included with the base Chonkie installation:
+
+```bash
+pip install chonkie
+```
+
+## Usage
+
+### Single File Mode
+
+Fetch a single file by providing the `path` parameter:
+
+```python
+from chonkie.pipeline import Pipeline
+
+# Fetch and process a single file
+doc = (Pipeline()
+    .fetch_from("file", path="document.txt")
+    .process_with("text")
+    .chunk_with("recursive", chunk_size=512)
+    .run())
+
+print(f"Chunked into {len(doc.chunks)} chunks")
+```
+
+### Directory Mode
+
+Fetch multiple files from a directory using the `dir` parameter:
+
+```python
+# Fetch all files from a directory
+docs = (Pipeline()
+    .fetch_from("file", dir="./documents")
+    .process_with("text")
+    .chunk_with("recursive", chunk_size=512)
+    .run())
+
+print(f"Processed {len(docs)} documents")
+for doc in docs:
+    print(f"  - {len(doc.chunks)} chunks")
+```
+
+### Extension Filtering
+
+Filter files by extension when using directory mode:
+
+```python
+# Fetch only .txt and .md files
+docs = (Pipeline()
+    .fetch_from("file", dir="./documents", ext=[".txt", ".md"])
+    .process_with("text")
+    .chunk_with("recursive", chunk_size=512)
+    .run())
+```
+
+## Parameters
+
+<ParamField path="path" type="str" optional>
+  Path to a single file. Cannot be used with `dir`.
+</ParamField>
+
+<ParamField path="dir" type="str" optional>
+  Directory to fetch files from. Cannot be used with `path`.
+</ParamField>
+
+<ParamField path="ext" type="List[str]" optional>
+  List of file extensions to filter (e.g., `[".txt", ".md"]`). Only used with `dir` parameter.
+</ParamField>
+
+## Return Values
+
+- **Single file mode** (`path` provided): Returns a single `Path` object
+- **Directory mode** (`dir` provided): Returns `List[Path]` containing all matching files
+
+## Standalone Usage
+
+You can also use FileFetcher directly without the pipeline:
+
+```python
+from chonkie import FileFetcher
+
+fetcher = FileFetcher()
+
+# Single file
+file_path = fetcher.fetch(path="document.txt")
+print(file_path)  # PosixPath('document.txt')
+
+# Directory with extension filter
+files = fetcher.fetch(dir="./docs", ext=[".txt", ".md"])
+for file in files:
+    print(file)
+```
+
+## Error Handling
+
+FileFetcher validates inputs and provides clear error messages:
+
+```python
+# FileNotFoundError if file doesn't exist
+fetcher.fetch(path="nonexistent.txt")  # Raises FileNotFoundError
+
+# ValueError if both path and dir are provided
+fetcher.fetch(path="file.txt", dir="./docs")  # Raises ValueError
+
+# ValueError if neither is provided
+fetcher.fetch()  # Raises ValueError
+```
+
+## Best Practices
+
+<AccordionGroup>
+  <Accordion title="Use extension filtering for large directories">
+    When working with directories containing many files, always specify `ext` to avoid processing unwanted files:
+
+    ```python
+    # Good - only processes markdown files
+    .fetch_from("file", dir="./docs", ext=[".md"])
+
+    # Potentially slow - processes ALL files
+    .fetch_from("file", dir="./docs")
+    ```
+  </Accordion>
+
+  <Accordion title="Use absolute paths for clarity">
+    While relative paths work, absolute paths make your pipeline more portable:
+
+    ```python
+    from pathlib import Path
+
+    docs_dir = Path(__file__).parent / "documents"
+    .fetch_from("file", dir=str(docs_dir), ext=[".txt"])
+    ```
+  </Accordion>
+</AccordionGroup>
+
+## What's Next?
+
+After fetching files, you'll typically want to:
+1. **Process** them with a [Chef](/oss/chefs/overview) to parse content
+2. **Chunk** them with a [Chunker](/oss/chunkers/overview) to split into manageable pieces
+3. **Refine** chunks with [Refineries](/oss/refineries/overview) for better quality
+
+See the [Pipeline Guide](/oss/pipeline) for complete examples.

--- a/docs/oss/fetchers/overview.mdx
+++ b/docs/oss/fetchers/overview.mdx
@@ -1,0 +1,64 @@
+---
+title: Fetchers Overview
+sidebarTitle: Overview
+description: Overview of the different fetchers available in Chonkie
+icon: "download"
+iconType: "solid"
+---
+
+Fetchers connect different data sources to Chonkie's pipeline system, enabling seamless data ingestion from various sources.
+
+## What are Fetchers?
+
+Fetchers are the first step in the CHOMP pipeline (CHef -> CHunker -> Refinery -> Porter/Handshake). They retrieve data from different sources and pass it to the next pipeline stage for processing. Fetchers make it easy to:
+
+- Load files from local storage
+- Fetch documents from cloud storage (coming soon)
+- Retrieve data from databases (coming soon)
+- Connect to APIs and web sources (coming soon)
+
+## Installation
+
+Fetchers are included with the base Chonkie installation:
+
+```bash
+pip install chonkie
+```
+
+## Using Fetchers in Pipelines
+
+Fetchers integrate seamlessly with the Pipeline API:
+
+```python
+from chonkie.pipeline import Pipeline
+
+# Single file
+doc = (Pipeline()
+    .fetch_from("file", path="document.txt")
+    .process_with("text")
+    .chunk_with("recursive", chunk_size=512)
+    .run())
+
+# Directory with multiple files
+docs = (Pipeline()
+    .fetch_from("file", dir="./docs", ext=[".txt", ".md"])
+    .process_with("text")
+    .chunk_with("recursive", chunk_size=512)
+    .run())
+```
+
+## Available Fetchers
+
+<CardGroup cols={2}>
+  <Card
+    title="FileFetcher"
+    icon="file"
+    href="/oss/fetchers/file-fetcher"
+  >
+    Fetch files from local filesystem - single files or entire directories.
+  </Card>
+</CardGroup>
+
+<Info>
+  More fetchers are coming soon! We're working on cloud storage, database, and API fetchers.
+</Info>

--- a/docs/oss/pipelines.mdx
+++ b/docs/oss/pipelines.mdx
@@ -1,0 +1,446 @@
+---
+title: Building Pipelines
+sidebarTitle: Pipelines
+description: Build powerful text processing workflows with Chonkie's Pipeline API
+icon: "diagram-project"
+iconType: "solid"
+---
+
+Chonkie's Pipeline API provides a fluent, chainable interface for building text processing workflows. Pipelines follow the **CHOMP architecture**, automatically orchestrating components in the correct order.
+
+## What is CHOMP?
+
+CHOMP (CHOnkie's Multi-step Pipeline) is our standardized architecture for document processing:
+
+```
+Fetcher → Chef → Chunker → Refinery → Porter/Handshake
+```
+
+<Steps>
+  <Step title="Fetcher">
+    Retrieve raw data from files, APIs, or databases
+  </Step>
+  <Step title="Chef">
+    Preprocess and transform raw data into Documents
+  </Step>
+  <Step title="Chunker">
+    Split documents into manageable chunks
+  </Step>
+  <Step title="Refinery (Optional)">
+    Post-process and enhance chunks
+  </Step>
+  <Step title="Porter/Handshake (Optional)">
+    Export or store chunks
+  </Step>
+</Steps>
+
+<Info>
+  Pipelines automatically reorder components to follow CHOMP, so you can add them in any order.
+</Info>
+
+## Quick Start
+
+### Single File Processing
+
+```python
+from chonkie.pipeline import Pipeline
+
+# Build and execute pipeline
+doc = (Pipeline()
+    .fetch_from("file", path="document.txt")
+    .process_with("text")
+    .chunk_with("recursive", chunk_size=512)
+    .run())
+
+# Access chunks
+print(f"Created {len(doc.chunks)} chunks")
+for chunk in doc.chunks:
+    print(f"Chunk: {chunk.text[:50]}...")
+```
+
+### Directory Processing
+
+Process multiple files at once:
+
+```python
+# Process all markdown files in a directory
+docs = (Pipeline()
+    .fetch_from("file", dir="./documents", ext=[".md", ".txt"])
+    .process_with("text")
+    .chunk_with("recursive", chunk_size=512)
+    .run())
+
+# Process each document
+for doc in docs:
+    print(f"Document has {len(doc.chunks)} chunks")
+```
+
+### Direct Text Input
+
+Skip the fetcher and provide text directly:
+
+```python
+# No fetcher needed
+doc = (Pipeline()
+    .process_with("text")
+    .chunk_with("semantic", threshold=0.8)
+    .run(texts="Your text here"))
+
+# Multiple texts
+docs = (Pipeline()
+    .chunk_with("recursive", chunk_size=512)
+    .run(texts=["Text 1", "Text 2", "Text 3"]))
+```
+
+## Pipeline Methods
+
+### fetch_from()
+
+Fetch data from a source:
+
+```python
+# Single file
+.fetch_from("file", path="document.txt")
+
+# Directory with extension filter
+.fetch_from("file", dir="./docs", ext=[".txt", ".md"])
+```
+
+### process_with()
+
+Process data with a chef:
+
+```python
+# Text processing
+.process_with("text")
+
+# Markdown processing
+.process_with("markdown")
+
+# Table processing
+.process_with("table")
+```
+
+### chunk_with()
+
+Chunk documents (required):
+
+```python
+# Recursive chunking
+.chunk_with("recursive", chunk_size=512, chunk_overlap=50)
+
+# Semantic chunking
+.chunk_with("semantic", threshold=0.8, chunk_size=1024)
+
+# Code chunking
+.chunk_with("code", chunk_size=512)
+```
+
+### refine_with()
+
+Refine chunks (optional, can chain multiple):
+
+```python
+# Add overlap context
+.refine_with("overlap", context_size=100, method="prefix")
+
+# Add embeddings
+.refine_with("embedding", model="text-embedding-3-small")
+```
+
+### export_with()
+
+Export chunks to formats (optional):
+
+```python
+# Export to JSON
+.export_with("json", file="chunks.json")
+
+# Export to Hugging Face Datasets
+.export_with("datasets", name="my-dataset")
+```
+
+### store_in()
+
+Store in vector databases (optional):
+
+```python
+# Store in Chroma
+.store_in("chroma", collection_name="documents")
+
+# Store in Qdrant
+.store_in("qdrant", collection_name="docs", url="http://localhost:6333")
+```
+
+## Advanced Examples
+
+### RAG Knowledge Base
+
+Build a complete RAG ingestion pipeline:
+
+```python
+# Ingest documents into vector database
+docs = (Pipeline()
+    .fetch_from("file", dir="./knowledge_base", ext=[".txt", ".md"])
+    .process_with("text")
+    .chunk_with("semantic", threshold=0.8, chunk_size=1024)
+    .refine_with("overlap", context_size=100)
+    .store_in("qdrant",
+              collection_name="knowledge",
+              url="http://localhost:6333")
+    .run())
+
+print(f"Ingested {len(docs)} documents")
+```
+
+### Semantic Search Pipeline
+
+Process documents with embeddings for search:
+
+```python
+# Chunk with embeddings
+doc = (Pipeline()
+    .fetch_from("file", path="research_paper.txt")
+    .process_with("text")
+    .chunk_with("semantic",
+                threshold=0.8,
+                chunk_size=1024,
+                similarity_window=3)
+    .refine_with("overlap", context_size=100)
+    .refine_with("embedding", model="minishlab/potion-base-32M")
+    .run())
+
+# All chunks now have embeddings
+for chunk in doc.chunks:
+    if chunk.embedding is not None:
+        print(f"Chunk: {chunk.text[:30]}... | Embedding shape: {chunk.embedding.shape}")
+```
+
+### Code Documentation
+
+Process code with specialized chunking:
+
+```python
+# Chunk Python files
+docs = (Pipeline()
+    .fetch_from("file", dir="./src", ext=[".py"])
+    .chunk_with("code", chunk_size=512)
+    .export_with("json", file="code_chunks.json")
+    .run())
+
+print(f"Processed {len(docs)} Python files")
+```
+
+### Markdown Processing
+
+Handle markdown with table and code awareness:
+
+```python
+# Process markdown documentation
+doc = (Pipeline()
+    .fetch_from("file", path="README.md")
+    .process_with("markdown")
+    .chunk_with("recursive", chunk_size=512)
+    .run())
+
+# Access markdown metadata
+print(f"Found {len(doc.tables)} tables")
+print(f"Found {len(doc.code)} code blocks")
+print(f"Created {len(doc.chunks)} chunks")
+```
+
+## Recipe-Based Pipelines
+
+Load pre-configured pipelines from the Chonkie Hub:
+
+```python
+# Load markdown processing recipe
+pipeline = Pipeline.from_recipe("markdown")
+
+# Run with your content
+doc = pipeline.run(texts="# My Markdown\n\nContent here")
+
+# Load custom local recipe
+pipeline = Pipeline.from_recipe("custom", path="./my_recipe.json")
+```
+
+<Note>
+  Recipes are stored in the [chonkie-ai/recipes](https://huggingface.co/chonkie-ai/recipes) repository.
+</Note>
+
+## Best Practices
+
+<AccordionGroup>
+  <Accordion title="Always specify chunk_size">
+    Explicitly set `chunk_size` for predictable behavior:
+
+    ```python
+    # Good - explicit size
+    .chunk_with("recursive", chunk_size=512)
+
+    # Avoid - uses defaults that may change
+    .chunk_with("recursive")
+    ```
+  </Accordion>
+
+  <Accordion title="Match chunkers to content type">
+    Choose chunkers appropriate for your content:
+
+    ```python
+    # Code files → Code chunker
+    .chunk_with("code")
+
+    # Need semantic similarity → Semantic chunker
+    .chunk_with("semantic", threshold=0.8)
+
+    # General text → Recursive chunker
+    .chunk_with("recursive")
+    ```
+  </Accordion>
+
+  <Accordion title="Use refineries for RAG applications">
+    Add overlap refineries for better retrieval context:
+
+    ```python
+    .chunk_with("recursive", chunk_size=512)
+    .refine_with("overlap", context_size=100)
+    ```
+  </Accordion>
+
+  <Accordion title="Filter extensions in directory mode">
+    Always specify file extensions to avoid unwanted files:
+
+    ```python
+    # Good - filtered
+    .fetch_from("file", dir="./docs", ext=[".txt", ".md"])
+
+    # Bad - processes everything including binaries
+    .fetch_from("file", dir="./docs")
+    ```
+  </Accordion>
+
+  <Accordion title="Chain refineries for complex processing">
+    Multiple refineries can be chained:
+
+    ```python
+    .chunk_with("recursive", chunk_size=512)
+    .refine_with("overlap", context_size=50)
+    .refine_with("embedding", model="text-embedding-3-small")
+    ```
+  </Accordion>
+</AccordionGroup>
+
+## Pipeline Validation
+
+Pipelines validate configuration before execution:
+
+✅ **Must have**: At least one chunker
+✅ **Must have**: Fetcher OR text input via `run(texts=...)`
+❌ **Cannot have**: Multiple chefs (only one allowed)
+
+```python
+# ❌ Invalid - no chunker
+Pipeline().fetch_from("file", path="doc.txt").run()
+
+# ❌ Invalid - multiple chefs
+Pipeline()
+    .process_with("text")
+    .process_with("markdown")  # Error!
+    .chunk_with("recursive")
+
+# ✅ Valid - has chunker and input source
+Pipeline()
+    .fetch_from("file", path="doc.txt")
+    .chunk_with("recursive", chunk_size=512)
+    .run()
+
+# ✅ Valid - text input, no fetcher needed
+Pipeline()
+    .chunk_with("recursive")
+    .run(texts="Hello world")
+```
+
+## Return Values
+
+Pipeline behavior depends on input:
+
+- **Single file/text**: Returns `Document`
+- **Multiple files/texts**: Returns `List[Document]`
+
+```python
+# Single file → Document
+doc = Pipeline().fetch_from("file", path="doc.txt").chunk_with("recursive").run()
+assert isinstance(doc, Document)
+
+# Directory → List[Document]
+docs = Pipeline().fetch_from("file", dir="./docs").chunk_with("recursive").run()
+assert isinstance(docs, list)
+
+# Multiple texts → List[Document]
+docs = Pipeline().chunk_with("recursive").run(texts=["t1", "t2"])
+assert isinstance(docs, list)
+```
+
+## Error Handling
+
+Pipelines provide clear error messages:
+
+```python
+from pathlib import Path
+
+try:
+    doc = Pipeline()
+        .fetch_from("file", path="missing.txt")
+        .chunk_with("recursive")
+        .run()
+except FileNotFoundError as e:
+    print(f"File not found: {e}")
+except ValueError as e:
+    print(f"Configuration error: {e}")
+except RuntimeError as e:
+    print(f"Pipeline execution failed: {e}")
+```
+
+## Component Overview
+
+### Available Components
+
+Explore each component type:
+
+<CardGroup cols={2}>
+  <Card title="Fetchers" icon="download" href="/oss/fetchers/overview">
+    Connect to data sources (files, APIs, databases)
+  </Card>
+  <Card title="Chefs" icon="hat-chef" href="/oss/chefs/overview">
+    Preprocess text, markdown, tables, etc.
+  </Card>
+  <Card title="Chunkers" icon="scissors" href="/oss/chunkers/overview">
+    Split text with various strategies
+  </Card>
+  <Card title="Refineries" icon="wand-magic-sparkles" href="/oss/refinery/overview">
+    Add overlap, embeddings, and more
+  </Card>
+  <Card title="Porters" icon="file-export" href="/oss/porters/overview">
+    Export to JSON, Datasets, etc.
+  </Card>
+  <Card title="Handshakes" icon="database" href="/oss/handshakes/overview">
+    Store in Chroma, Qdrant, Pinecone, etc.
+  </Card>
+</CardGroup>
+
+## What's Next?
+
+<Steps>
+  <Step title="Explore Fetchers">
+    Learn how to connect different data sources in [Fetchers](/oss/fetchers/overview)
+  </Step>
+  <Step title="Choose Your Chunker">
+    Find the right chunking strategy in [Chunkers](/oss/chunkers/overview)
+  </Step>
+  <Step title="Enhance with Refineries">
+    Improve chunk quality in [Refineries](/oss/refinery/overview)
+  </Step>
+  <Step title="Store Your Chunks">
+    Ingest into vector databases with [Handshakes](/oss/handshakes/overview)
+  </Step>
+</Steps>

--- a/src/chonkie/fetcher/file.py
+++ b/src/chonkie/fetcher/file.py
@@ -1,7 +1,7 @@
 """FileFetcher is a fetcher that fetches paths of files from local directories."""
 
 from pathlib import Path
-from typing import List, Optional
+from typing import List, Optional, Union
 
 from chonkie.pipeline import fetcher
 
@@ -10,29 +10,66 @@ from .base import BaseFetcher
 
 @fetcher("file")
 class FileFetcher(BaseFetcher):
-    """FileFetcher is a fetcher that fetches paths of files from local directories."""
+    """FileFetcher fetches a single file or multiple files from a directory.
+
+    Supports two modes:
+    - Single file mode: provide 'path' parameter
+    - Directory mode: provide 'dir' parameter (optionally with 'ext' filter)
+    """
 
     def __init__(self) -> None:
         """Initialize the FileFetcher."""
         super().__init__()
 
-    def fetch(self, dir: str, ext: Optional[List[str]] = None) -> List[Path]:
-        """Fetch files from a directory.
+    def fetch(
+        self,
+        path: Optional[str] = None,
+        dir: Optional[str] = None,
+        ext: Optional[List[str]] = None,
+    ) -> Union[Path, List[Path]]:
+        """Fetch a single file or files from a directory.
 
         Args:
-            dir (str): The directory to fetch files from.
-            ext (Optional[List[str]]): The file extensions to fetch.
+            path: Path to a single file
+            dir: Directory to fetch files from
+            ext: File extensions to filter (only used with dir parameter)
 
         Returns:
-            List[Path]: The list of files fetched from the directory.
+            Union[Path, List[Path]]: Single Path for file mode, List[Path] for directory mode
+
+        Raises:
+            ValueError: If neither or both path and dir are provided
+            FileNotFoundError: If the specified file doesn't exist
+
+        Examples:
+            ```python
+            # Single file mode
+            fetcher.fetch(path="document.txt")
+
+            # Directory mode
+            fetcher.fetch(dir="./docs", ext=[".txt", ".md"])
+            ```
 
         """
-        # Reads the entire directory and returns a list of files with the specified extension
-        return [
-            file
-            for file in Path(dir).iterdir()
-            if file.is_file() and (ext is None or file.suffix in ext)
-        ]
+        if path is not None and dir is not None:
+            raise ValueError("Provide either 'path' or 'dir', not both")
+
+        if path is not None:
+            # Single file mode
+            file_path = Path(path)
+            if not file_path.is_file():
+                raise FileNotFoundError(f"File not found: {path}")
+            return file_path
+
+        elif dir is not None:
+            # Directory mode (current behavior)
+            return [
+                file
+                for file in Path(dir).iterdir()
+                if file.is_file() and (ext is None or file.suffix in ext)
+            ]
+        else:
+            raise ValueError("Must provide either 'path' or 'dir'")
 
     def fetch_file(self, dir: str, name: str) -> Path:  # type: ignore[override]
         """Given a directory and a file name, return the path to the file.
@@ -46,15 +83,21 @@ class FileFetcher(BaseFetcher):
                 return file
         raise FileNotFoundError(f"File {name} not found in directory {dir}")
 
-    def __call__(self, dir: str, ext: Optional[List[str]] = None) -> List[Path]:  # type: ignore[override]
-        """Fetch files from a directory.
+    def __call__(
+        self,
+        path: Optional[str] = None,
+        dir: Optional[str] = None,
+        ext: Optional[List[str]] = None,
+    ) -> Union[Path, List[Path]]:  # type: ignore[override]
+        """Fetch a single file or files from a directory.
 
         Args:
-            dir (str): The directory to fetch files from.
-            ext (Optional[List[str]]): The file extensions to fetch.
+            path: Path to a single file
+            dir: Directory to fetch files from
+            ext: File extensions to filter (only used with dir parameter)
 
         Returns:
-            List[Path]: The list of files fetched from the directory.
+            Union[Path, List[Path]]: Single Path for file mode, List[Path] for directory mode
 
         """
-        return self.fetch(dir, ext)
+        return self.fetch(path=path, dir=dir, ext=ext)

--- a/src/chonkie/pipeline/pipeline.py
+++ b/src/chonkie/pipeline/pipeline.py
@@ -17,11 +17,11 @@ class Pipeline:
     The Pipeline class provides a clean, chainable interface for processing
     documents through the CHOMP pipeline: CHef -> CHunker -> Refinery -> Porter/Handshake.
 
-    Example:
+    Examples:
         ```python
         from chonkie.pipeline import Pipeline
 
-        # Simple pipeline - returns Document with chunks
+        # Simple pipeline with single file - returns Document with chunks
         doc = (Pipeline()
             .fetch_from("file", path="document.txt")
             .process_with("text")
@@ -31,6 +31,13 @@ class Pipeline:
         # Access chunks via doc.chunks
         for chunk in doc.chunks:
             print(chunk.text)
+
+        # Process multiple files from directory - returns List[Document]
+        docs = (Pipeline()
+            .fetch_from("file", dir="./docs", ext=[".txt", ".md"])
+            .process_with("text")
+            .chunk_with("recursive", chunk_size=512)
+            .run())
 
         # Complex pipeline with refinement and export
         doc = (Pipeline()
@@ -185,9 +192,13 @@ class Pipeline:
         Raises:
             ValueError: If source_type is not a registered fetcher
 
-        Example:
+        Examples:
             ```python
+            # Single file
             pipeline.fetch_from("file", path="document.txt")
+
+            # Directory with extension filter
+            pipeline.fetch_from("file", dir="./docs", ext=[".txt", ".md"])
             ```
 
         """
@@ -336,13 +347,22 @@ class Pipeline:
 
         Examples:
             ```python
-            # Traditional fetcher-based pipeline - returns Document
+            # Single file pipeline - returns Document
             pipeline = (Pipeline()
                 .fetch_from("file", path="doc.txt")
                 .process_with("text")
                 .chunk_with("recursive", chunk_size=512))
             doc = pipeline.run()
             print(f"Chunked into {len(doc.chunks)} chunks")
+
+            # Directory pipeline - returns List[Document]
+            pipeline = (Pipeline()
+                .fetch_from("file", dir="./docs", ext=[".txt", ".md"])
+                .process_with("text")
+                .chunk_with("recursive", chunk_size=512))
+            docs = pipeline.run()
+            for doc in docs:
+                print(f"File chunked into {len(doc.chunks)} chunks")
 
             # Direct text input (fetcher optional)
             pipeline = (Pipeline()


### PR DESCRIPTION
This pull request expands and improves the documentation and functionality of file fetching in the Chonkie pipeline, focusing on making the `FileFetcher` more flexible and user-friendly. It introduces support for both single-file and directory modes, updates the API and documentation accordingly, and adds comprehensive usage examples for both developers and users.

**Documentation Enhancements:**

* Added a new "Fetchers" documentation section, including an overview and a detailed page for `FileFetcher`, describing its usage, parameters, return values, error handling, and best practices. [[1]](diffhunk://#diff-873ce17c654718debe2fe308a2f2279bde8663686423c51f97fab2dd0722b8d9R48-R54) [[2]](diffhunk://#diff-29e054cf39ef6025aa8712472abfb086d26d91b0314e2f2d4e81e630c84407eaR1-R64) [[3]](diffhunk://#diff-a0339e2bf80ffab046ea180f4c95b38e09205ebd34f3b68a1f684131c637fa3dR1-R155)
* Updated the documentation navigation to include the new "Fetchers" group and the "pipelines" page for better discoverability.

**`FileFetcher` Functionality Improvements:**

* Refactored `FileFetcher` in `file.py` to support fetching either a single file (with the `path` parameter) or multiple files from a directory (with the `dir` parameter and optional `ext` filter), including input validation and clear error messages. Both the `fetch` and `__call__` methods now support this behavior. [[1]](diffhunk://#diff-4211cccbec152527003fb20621f8ca91f525a4fd7dff56aaaf329f7d4b179528L4-R4) [[2]](diffhunk://#diff-4211cccbec152527003fb20621f8ca91f525a4fd7dff56aaaf329f7d4b179528L13-R72) [[3]](diffhunk://#diff-4211cccbec152527003fb20621f8ca91f525a4fd7dff56aaaf329f7d4b179528L49-R103)

**Pipeline API and Example Updates:**

* Updated the `Pipeline` class and all relevant docstrings to demonstrate both single-file and directory-based workflows, including expected return types and usage patterns. [[1]](diffhunk://#diff-098bfc56e95a8b6a4fdafe064f3eb4d6fe788d5c5192feca7609d012889a54a1L20-R24) [[2]](diffhunk://#diff-098bfc56e95a8b6a4fdafe064f3eb4d6fe788d5c5192feca7609d012889a54a1R35-R41) [[3]](diffhunk://#diff-098bfc56e95a8b6a4fdafe064f3eb4d6fe788d5c5192feca7609d012889a54a1L188-R201) [[4]](diffhunk://#diff-098bfc56e95a8b6a4fdafe064f3eb4d6fe788d5c5192feca7609d012889a54a1L339-R366)documentation pages