### PR TITLE
Fix(#317): `add_special_tokens` is no longer supported in `SentenceTransformers.encode()`

### DIFF
--- a/src/chonkie/embeddings/sentence_transformer.py
+++ b/src/chonkie/embeddings/sentence_transformer.py
@@ -85,10 +85,7 @@ class SentenceTransformerEmbeddings(BaseEmbeddings):
                 token_splits.append(encodings[i:])
 
         split_texts = self.model.tokenizer.batch_decode(token_splits)
-        # Get the token embeddings
-        token_embeddings = self.model.encode(
-            split_texts, output_value="token_embeddings"
-        )
+        token_embeddings = self.model.encode(split_texts, output_value="token_embeddings")
 
         # Since SentenceTransformer doesn't automatically convert embeddings into
         # numpy arrays, we need to do it manually


### PR DESCRIPTION
This pull request makes a minor formatting change to the `embed_as_tokens` method in `sentence_transformer.py`, consolidating the call to `self.model.encode` into a single line for improved readability.

- Code formatting:
  * Combined the multi-line call to `self.model.encode` into a single line in the `embed_as_tokens` method of `sentence_transformer.py` for cleaner code.