### PR TITLE
Increase logo size in welcome page

### DIFF
--- a/docs/common/welcome.mdx
+++ b/docs/common/welcome.mdx
@@ -13,16 +13,16 @@ mode: "wide"
     src="/assets/logo/chonkie_logo_br_transparent_bg.png"
     alt="Chonkie Logo Light"
     noZoom
-    height="400"
-    width="400"
+    height="550"
+    width="550"
   />
   <img
     className="hidden dark:block"
     src="/assets/logo/chonkie_logo_br_transparent_bg.png"
     alt="Chonkie Logo Dark"
     noZoom
-    height="400"
-    width="400"
+    height="550"
+    width="550"
   />
 </div>
 


### PR DESCRIPTION
This pull request makes a minor update to the `docs/common/welcome.mdx` file, increasing the displayed size of the Chonkie logo images. The height and width of both the light and dark mode logos have been set to 550 pixels instead of 400 pixels.