### PR TITLE
Docs: Update chunker documentation with two-step file upload process

### DIFF
--- a/docs/api/chunkers/code-chunker.mdx
+++ b/docs/api/chunkers/code-chunker.mdx
@@ -74,17 +74,30 @@ const chunker = new CodeChunker({
   chunkSize: 512,
 });
 
-// Chunk from file
-const file = document.querySelector('input[type="file"]').files[0];
-const chunks = await chunker.chunk({ file });
+// Chunk from file path (Node.js)
+const chunks = await chunker.chunk({ filepath: './script.py' });
 ```
 
 ```bash cURL
+# Step 1: Upload the file
+curl -X POST https://api.chonkie.ai/v1/files \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -F "file=@script.py"
+
+# Returns: {"name": "script.py", "size": "2048"}
+
+# Step 2: Chunk the uploaded file
 curl -X POST https://api.chonkie.ai/v1/chunk/code \
   -H "Authorization: Bearer YOUR_API_KEY" \
-  -F "file=@script.py" \
-  -F "language=python" \
-  -F "chunk_size=512"
+  -H "Content-Type: application/json" \
+  -d '{
+    "file": {
+      "type": "document",
+      "content": "script.py"
+    },
+    "language": "python",
+    "chunk_size": 512
+  }'
 ```
 
 </CodeGroup>

--- a/docs/api/chunkers/late-chunker.mdx
+++ b/docs/api/chunkers/late-chunker.mdx
@@ -74,17 +74,30 @@ const chunker = new LateChunker({
   chunkSize: 512,
 });
 
-// Chunk from file
-const file = document.querySelector('input[type="file"]').files[0];
-const chunks = await chunker.chunk({ file });
+// Chunk from file path (Node.js)
+const chunks = await chunker.chunk({ filepath: './document.txt' });
 ```
 
 ```bash cURL
+# Step 1: Upload the file
+curl -X POST https://api.chonkie.ai/v1/files \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -F "file=@document.txt"
+
+# Returns: {"name": "document.txt", "size": "1024"}
+
+# Step 2: Chunk the uploaded file
 curl -X POST https://api.chonkie.ai/v1/chunk/late \
   -H "Authorization: Bearer YOUR_API_KEY" \
-  -F "file=@document.txt" \
-  -F "embedding_model=minishlab/potion-base-8M" \
-  -F "chunk_size=512"
+  -H "Content-Type: application/json" \
+  -d '{
+    "file": {
+      "type": "document",
+      "content": "document.txt"
+    },
+    "embedding_model": "minishlab/potion-base-8M",
+    "chunk_size": 512
+  }'
 ```
 
 </CodeGroup>

--- a/docs/api/chunkers/neural-chunker.mdx
+++ b/docs/api/chunkers/neural-chunker.mdx
@@ -69,16 +69,29 @@ const chunker = new NeuralChunker({
   model:"mirth/chonky_modernbert_large_1"
 });
 
-// Chunk from file
-const file = document.querySelector('input[type="file"]').files[0];
-const chunks = await chunker.chunk({ file });
+// Chunk from file path (Node.js)
+const chunks = await chunker.chunk({ filepath: './document.txt' });
 ```
 
 ```bash cURL
+# Step 1: Upload the file
+curl -X POST https://api.chonkie.ai/v1/files \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -F "file=@document.txt"
+
+# Returns: {"name": "document.txt", "size": "1024"}
+
+# Step 2: Chunk the uploaded file
 curl -X POST https://api.chonkie.ai/v1/chunk/neural \
   -H "Authorization: Bearer YOUR_API_KEY" \
-  -F "file=@document.txt" \
-  -F "model=mirth/chonky_modernbert_large_1"
+  -H "Content-Type: application/json" \
+  -d '{
+    "file": {
+      "type": "document",
+      "content": "document.txt"
+    },
+    "model": "mirth/chonky_modernbert_large_1"
+  }'
 ```
 
 </CodeGroup>

--- a/docs/api/chunkers/recursive-chunker.mdx
+++ b/docs/api/chunkers/recursive-chunker.mdx
@@ -78,18 +78,31 @@ const chunker = new RecursiveChunker({
   recipe: "markdown"
 });
 
-// Chunk from file
-const file = document.querySelector('input[type="file"]').files[0];
-const chunks = await chunker.chunk({ file });
+// Chunk from file path (Node.js)
+const chunks = await chunker.chunk({ filepath: './document.txt' });
 ```
 
 ```bash cURL
+# Step 1: Upload the file
+curl -X POST https://api.chonkie.ai/v1/files \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -F "file=@document.txt"
+
+# Returns: {"name": "document.txt", "size": "1024"}
+
+# Step 2: Chunk the uploaded file
 curl -X POST https://api.chonkie.ai/v1/chunk/recursive \
   -H "Authorization: Bearer YOUR_API_KEY" \
-  -F "file=@document.txt" \
-  -F "chunk_size=512" \
-  -F "chunk_overlap=128" \
-  -F "recipe=markdown"
+  -H "Content-Type: application/json" \
+  -d '{
+    "file": {
+      "type": "document",
+      "content": "document.txt"
+    },
+    "chunk_size": 512,
+    "chunk_overlap": 128,
+    "recipe": "markdown"
+  }'
 ```
 
 </CodeGroup>

--- a/docs/api/chunkers/semantic-chunker.mdx
+++ b/docs/api/chunkers/semantic-chunker.mdx
@@ -74,17 +74,30 @@ const chunker = new SemanticChunker({
   chunkSize: 512,
 });
 
-// Chunk from file
-const file = document.querySelector('input[type="file"]').files[0];
-const chunks = await chunker.chunk({ file });
+// Chunk from file path (Node.js)
+const chunks = await chunker.chunk({ filepath: './document.txt' });
 ```
 
 ```bash cURL
+# Step 1: Upload the file
+curl -X POST https://api.chonkie.ai/v1/files \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -F "file=@document.txt"
+
+# Returns: {"name": "document.txt", "size": "1024"}
+
+# Step 2: Chunk the uploaded file
 curl -X POST https://api.chonkie.ai/v1/chunk/semantic \
   -H "Authorization: Bearer YOUR_API_KEY" \
-  -F "file=@document.txt" \
-  -F "embedding_model=minishlab/potion-base-8M" \
-  -F "chunk_size=512"
+  -H "Content-Type: application/json" \
+  -d '{
+    "file": {
+      "type": "document",
+      "content": "document.txt"
+    },
+    "embedding_model": "minishlab/potion-base-8M",
+    "chunk_size": 512
+  }'
 ```
 
 </CodeGroup>

--- a/docs/api/chunkers/sentence-chunker.mdx
+++ b/docs/api/chunkers/sentence-chunker.mdx
@@ -74,17 +74,30 @@ const chunker = new SentenceChunker({
   minSentencesPerChunk: 2,
 });
 
-// Chunk from file
-const file = document.querySelector('input[type="file"]').files[0];
-const chunks = await chunker.chunk({ file });
+// Chunk from file path (Node.js)
+const chunks = await chunker.chunk({ filepath: './document.txt' });
 ```
 
 ```bash cURL
+# Step 1: Upload the file
+curl -X POST https://api.chonkie.ai/v1/files \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -F "file=@document.txt"
+
+# Returns: {"name": "document.txt", "size": "1024"}
+
+# Step 2: Chunk the uploaded file
 curl -X POST https://api.chonkie.ai/v1/chunk/sentence \
   -H "Authorization: Bearer YOUR_API_KEY" \
-  -F "file=@document.txt" \
-  -F "chunk_size=512" \
-  -F "min_sentences_per_chunk=2"
+  -H "Content-Type: application/json" \
+  -d '{
+    "file": {
+      "type": "document",
+      "content": "document.txt"
+    },
+    "chunk_size": 512,
+    "min_sentences_per_chunk": 2
+  }'
 ```
 
 </CodeGroup>

--- a/docs/api/chunkers/slumber-chunker.mdx
+++ b/docs/api/chunkers/slumber-chunker.mdx
@@ -74,17 +74,30 @@ const chunker = new SlumberChunker({
   recipe: "markdown"
 });
 
-// Chunk from file
-const file = document.querySelector('input[type="file"]').files[0];
-const chunks = await chunker.chunk({ file });
+// Chunk from file path (Node.js)
+const chunks = await chunker.chunk({ filepath: './document.txt' });
 ```
 
 ```bash cURL
+# Step 1: Upload the file
+curl -X POST https://api.chonkie.ai/v1/files \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -F "file=@document.txt"
+
+# Returns: {"name": "document.txt", "size": "1024"}
+
+# Step 2: Chunk the uploaded file
 curl -X POST https://api.chonkie.ai/v1/chunk/slumber \
   -H "Authorization: Bearer YOUR_API_KEY" \
-  -F "file=@document.txt" \
-  -F "chunk_size=512" \
-  -F "recipe=markdown"
+  -H "Content-Type: application/json" \
+  -d '{
+    "file": {
+      "type": "document",
+      "content": "document.txt"
+    },
+    "chunk_size": 512,
+    "recipe": "markdown"
+  }'
 ```
 
 </CodeGroup>

--- a/docs/api/chunkers/token-chunker.mdx
+++ b/docs/api/chunkers/token-chunker.mdx
@@ -79,18 +79,31 @@ const chunker = new TokenChunker({
   chunkOverlap: 128
 });
 
-// Chunk from file
-const file = document.querySelector('input[type="file"]').files[0];
-const chunks = await chunker.chunk({ file });
+// Chunk from file path (Node.js)
+const chunks = await chunker.chunk({ filepath: './document.txt' });
 ```
 
 ```bash cURL
+# Step 1: Upload the file
+curl -X POST https://api.chonkie.ai/v1/files \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -F "file=@document.txt"
+
+# Returns: {"name": "document.txt", "size": "1024"}
+
+# Step 2: Chunk the uploaded file
 curl -X POST https://api.chonkie.ai/v1/chunk/token \
   -H "Authorization: Bearer YOUR_API_KEY" \
-  -F "file=@document.txt" \
-  -F "tokenizer=gpt2" \
-  -F "chunk_size=512" \
-  -F "chunk_overlap=128"
+  -H "Content-Type: application/json" \
+  -d '{
+    "file": {
+      "type": "document",
+      "content": "document.txt"
+    },
+    "tokenizer": "gpt2",
+    "chunk_size": 512,
+    "chunk_overlap": 128
+  }'
 ```
 
 </CodeGroup>


### PR DESCRIPTION
This pull request updates the documentation for all chunker API examples to improve clarity and consistency in how file chunking is demonstrated. The main changes include switching the JavaScript examples to use file paths (Node.js style) instead of browser file uploads, and revising the cURL examples to use a two-step process: first uploading the file, then chunking it using a JSON payload. This makes the documentation more accurate for typical backend usage and better reflects the API's workflow.

**Documentation improvements for chunker APIs:**

* Updated all JavaScript code samples to use file paths with the `chunker.chunk({ filepath: ... })` method, replacing browser file upload logic for consistency with Node.js usage. [[1]](diffhunk://#diff-0fead1dd39f6da55f7e98b49fecc9ba719c6ec926db877e9449d8aa21a52fb03L77-R100) [[2]](diffhunk://#diff-bfe620f1774d79594ec16a9b76fe617a5d72052cf56fca597de021f5888363e7L77-R100) [[3]](diffhunk://#diff-1ab1c109fa0ea47d33d6131500d70d83a6dc55979bea71b66189889c6886355aL72-R94) [[4]](diffhunk://#diff-43e8927953c1a054d56d4da277d27a4009dfe580bdad8b926663735f0078dc5cL81-R105) [[5]](diffhunk://#diff-7f403e65247df8728c313705b4756f9165cb44283b9ab8689a57df4117d9addeL77-R100) [[6]](diffhunk://#diff-d551ba0806ef31f7514a0f6766925cad2d579f9f9fa71717addee37cd4ff6a78L77-R100) [[7]](diffhunk://#diff-1e5380f166133cd9b9a58106ad562c62fec85478827f4237a006ec9799bbc24eL77-R100) [[8]](diffhunk://#diff-94f5b6bbbaff31aabfd17ddcb3ea3531fe8e3f26caa8fa2c5237f47f818ae0baL82-R106)
* Revised cURL examples to demonstrate a two-step workflow: first uploading the file to `/v1/files`, then chunking the uploaded file via a POST to the appropriate `/v1/chunk/{type}` endpoint using a JSON payload, replacing the previous multipart form-data approach. [[1]](diffhunk://#diff-0fead1dd39f6da55f7e98b49fecc9ba719c6ec926db877e9449d8aa21a52fb03L77-R100) [[2]](diffhunk://#diff-bfe620f1774d79594ec16a9b76fe617a5d72052cf56fca597de021f5888363e7L77-R100) [[3]](diffhunk://#diff-1ab1c109fa0ea47d33d6131500d70d83a6dc55979bea71b66189889c6886355aL72-R94) [[4]](diffhunk://#diff-43e8927953c1a054d56d4da277d27a4009dfe580bdad8b926663735f0078dc5cL81-R105) [[5]](diffhunk://#diff-7f403e65247df8728c313705b4756f9165cb44283b9ab8689a57df4117d9addeL77-R100) [[6]](diffhunk://#diff-d551ba0806ef31f7514a0f6766925cad2d579f9f9fa71717addee37cd4ff6a78L77-R100) [[7]](diffhunk://#diff-1e5380f166133cd9b9a58106ad562c62fec85478827f4237a006ec9799bbc24eL77-R100) [[8]](diffhunk://#diff-94f5b6bbbaff31aabfd17ddcb3ea3531fe8e3f26caa8fa2c5237f47f818ae0baL82-R106)
* Ensured all chunker documentation examples (code-chunker, late-chunker, neural-chunker, recursive-chunker, semantic-chunker, sentence-chunker, slumber-chunker, token-chunker) follow the same consistent pattern for file handling and API requests. [[1]](diffhunk://#diff-0fead1dd39f6da55f7e98b49fecc9ba719c6ec926db877e9449d8aa21a52fb03L77-R100) [[2]](diffhunk://#diff-bfe620f1774d79594ec16a9b76fe617a5d72052cf56fca597de021f5888363e7L77-R100) [[3]](diffhunk://#diff-1ab1c109fa0ea47d33d6131500d70d83a6dc55979bea71b66189889c6886355aL72-R94) [[4]](diffhunk://#diff-43e8927953c1a054d56d4da277d27a4009dfe580bdad8b926663735f0078dc5cL81-R105) [[5]](diffhunk://#diff-7f403e65247df8728c313705b4756f9165cb44283b9ab8689a57df4117d9addeL77-R100) [[6]](diffhunk://#diff-d551ba0806ef31f7514a0f6766925cad2d579f9f9fa71717addee37cd4ff6a78L77-R100) [[7]](diffhunk://#diff-1e5380f166133cd9b9a58106ad562c62fec85478827f4237a006ec9799bbc24eL77-R100) [[8]](diffhunk://#diff-94f5b6bbbaff31aabfd17ddcb3ea3531fe8e3f26caa8fa2c5237f47f818ae0baL82-R106)