### PR TITLE
Add missing import for AzureOpenAIEmbeddings in embeddings module

### DIFF
--- a/src/chonkie/embeddings/__init__.py
+++ b/src/chonkie/embeddings/__init__.py
@@ -1,6 +1,7 @@
 """Embeddings classes for text embedding."""
 
 from .auto import AutoEmbeddings
+from .azure_openai import AzureOpenAIEmbeddings
 from .base import BaseEmbeddings
 from .cohere import CohereEmbeddings
 from .gemini import GeminiEmbeddings
@@ -23,4 +24,5 @@ __all__ = [
     "JinaEmbeddings",
     "VoyageAIEmbeddings",
     "EmbeddingsRegistry",
+    "AzureOpenAIEmbeddings"
 ]


### PR DESCRIPTION
This PR fixes an import oversight in src/chonkie/embeddings/__init__.py by adding the missing AzureOpenAIEmbeddings class to both the module imports and the __all__ list.