### PR TITLE
Fix: Add update flow if the pipeline already exists on the `run()`

### DIFF
--- a/src/chonkie/cloud/pipeline.py
+++ b/src/chonkie/cloud/pipeline.py
@@ -381,10 +381,9 @@ class Pipeline:
             headers=self._get_headers(),
         )
 
-        if response.status_code == 409:
-            raise ValueError(f"Pipeline '{self._slug}' already exists.")
         if response.status_code != 200:
-            raise ValueError(f"Failed to save pipeline: {response.text}")
+            # Pipeline might already exist, try to update instead
+            return self.update()
 
         data = response.json()
         self._is_saved = True


### PR DESCRIPTION
This pull request updates the pipeline save logic to handle cases where the pipeline already exists by attempting an update instead of raising an error.

Error handling improvements:

* In `pipeline.py`, the `_save` method now attempts to update the pipeline if saving fails (e.g., due to a conflict or non-200 status), rather than raising an error when the pipeline already exists.