### PR TITLE
Fix: Pass-through original object type through pipeline registration functions

### DIFF
--- a/src/chonkie/pipeline/registry.py
+++ b/src/chonkie/pipeline/registry.py
@@ -1,8 +1,10 @@
 """Component registry for pipeline components."""
 
-from typing import Any, Callable, Dict, List, Optional, Type
+from typing import Any, Callable, Dict, List, Optional, Type, TypeVar
 
 from .component import Component, ComponentType
+
+ComponentT = TypeVar('ComponentT', bound=Type[Any])
 
 
 class _ComponentRegistry:
@@ -21,7 +23,7 @@ class _ComponentRegistry:
         self,
         name: str,
         alias: str,
-        component_class: Type[Any],
+        component_class: ComponentT,
         component_type: ComponentType,
     ) -> None:
         """Register a component in the registry.
@@ -302,7 +304,7 @@ class _ComponentRegistry:
 def pipeline_component(
     alias: str,
     component_type: ComponentType,
-) -> Callable[[Type[Any]], Type[Any]]:
+) -> Callable[[ComponentT], ComponentT]:
     """Register a class as a pipeline component.
 
     Args:
@@ -322,7 +324,7 @@ def pipeline_component(
 
     """
 
-    def decorator(cls: Type[Any]) -> Type[Any]:
+    def decorator(cls: ComponentT) -> ComponentT:
         # Validate that the class has ALL required methods
         required_methods = {
             ComponentType.FETCHER: ["fetch"],
@@ -363,7 +365,7 @@ def pipeline_component(
 
 
 # Specialized decorators for each component type
-def fetcher(alias: str) -> Callable[[Type[Any]], Type[Any]]:
+def fetcher(alias: str) -> Callable[[ComponentT], ComponentT]:
     """Register a fetcher component.
 
     Args:
@@ -381,7 +383,7 @@ def fetcher(alias: str) -> Callable[[Type[Any]], Type[Any]]:
     return pipeline_component(alias=alias, component_type=ComponentType.FETCHER)
 
 
-def chef(alias: str) -> Callable[[Type[Any]], Type[Any]]:
+def chef(alias: str) -> Callable[[ComponentT], ComponentT]:
     """Register a chef component.
 
     Args:
@@ -399,7 +401,7 @@ def chef(alias: str) -> Callable[[Type[Any]], Type[Any]]:
     return pipeline_component(alias=alias, component_type=ComponentType.CHEF)
 
 
-def chunker(alias: str) -> Callable[[Type[Any]], Type[Any]]:
+def chunker(alias: str) -> Callable[[ComponentT], ComponentT]:
     """Register a chunker component.
 
     Args:
@@ -417,7 +419,7 @@ def chunker(alias: str) -> Callable[[Type[Any]], Type[Any]]:
     return pipeline_component(alias=alias, component_type=ComponentType.CHUNKER)
 
 
-def refinery(alias: str) -> Callable[[Type[Any]], Type[Any]]:
+def refinery(alias: str) -> Callable[[ComponentT], ComponentT]:
     """Register a refinery component.
 
     Args:
@@ -435,7 +437,7 @@ def refinery(alias: str) -> Callable[[Type[Any]], Type[Any]]:
     return pipeline_component(alias=alias, component_type=ComponentType.REFINERY)
 
 
-def porter(alias: str) -> Callable[[Type[Any]], Type[Any]]:
+def porter(alias: str) -> Callable[[ComponentT], ComponentT]:
     """Register a porter component.
 
     Args:
@@ -453,7 +455,7 @@ def porter(alias: str) -> Callable[[Type[Any]], Type[Any]]:
     return pipeline_component(alias=alias, component_type=ComponentType.PORTER)
 
 
-def handshake(alias: str) -> Callable[[Type[Any]], Type[Any]]:
+def handshake(alias: str) -> Callable[[ComponentT], ComponentT]:
     """Register a handshake component.
 
     Args:


### PR DESCRIPTION
Without this, e.g. 

```python
handshake = QdrantHandshake(...)
```

will end up with `handshake` having the inferred type `Any` (e.g. in PyCharm), since that's basically what `-> Type[Any]` says.