### PR TITLE
Add support for custom Chonkie tokenizer instances

### DIFF
--- a/src/chonkie/embeddings/cohere.py
+++ b/src/chonkie/embeddings/cohere.py
@@ -1,6 +1,7 @@
 """Embeddings implementation using Cohere's API."""
 
 import importlib
+import importlib.util
 import os
 import warnings
 from typing import TYPE_CHECKING, List, Optional

--- a/src/chonkie/handshakes/pinecone.py
+++ b/src/chonkie/handshakes/pinecone.py
@@ -236,11 +236,11 @@ class PineconeHandshake(BaseHandshake):
         results = self.index.query(vector=embedding, top_k=limit, include_metadata=True)
 
         matches = []
-        for match in results.get("matches", []):
+        for match in results.get("matches", []):  # type: ignore[union-attr,call-arg,arg-type]
             matches.append({
-                "id": match.get("id"),
-                "score": match.get("score"),
-                **match.get("metadata", {}),
+                "id": match.get("id"),  # type: ignore[union-attr]
+                "score": match.get("score"),  # type: ignore[union-attr]
+                **match.get("metadata", {}),  # type: ignore[union-attr,arg-type]
             })
         logger.info(f"Search complete: found {len(matches)} matching chunks")
         return matches

--- a/src/chonkie/tokenizer.py
+++ b/src/chonkie/tokenizer.py
@@ -514,15 +514,13 @@ class AutoTokenizer:
 
         """
         if self._backend == "chonkie":
-            return self.tokenizer.decode_batch(token_sequences)  # type: ignore
+            return self.tokenizer.decode_batch(token_sequences)  # type: ignore[union-attr]
         elif self._backend in "tiktoken":
-            return self.tokenizer.decode_batch(token_sequences)  # type: ignore
+            return self.tokenizer.decode_batch(token_sequences)  # type: ignore[union-attr]
         elif self._backend in "tokenizers":
-            return self.tokenizer.decode_batch(token_sequences)  # type: ignore
+            return self.tokenizer.decode_batch(token_sequences)  # type: ignore[union-attr]
         elif self._backend == "transformers":
-            return self.tokenizer.batch_decode(
-                token_sequences, skip_special_tokens=True
-            )  # type: ignore
+            return self.tokenizer.batch_decode(token_sequences, skip_special_tokens=True)  # type: ignore[union-attr]
 
         if self._backend == "callable":
             raise NotImplementedError(
@@ -542,20 +540,15 @@ class AutoTokenizer:
 
         """
         if self._backend == "chonkie":
-            return self.tokenizer.count_tokens_batch(texts)  # type: ignore
+            return self.tokenizer.count_tokens_batch(texts)  # type: ignore[union-attr]
         elif self._backend == "tiktoken":
-            return [
-                len(token_list) for token_list in self.tokenizer.encode_batch(texts)
-            ]  # type: ignore
+            return [len(token_list) for token_list in self.tokenizer.encode_batch(texts)]  # type: ignore[union-attr,arg-type]
         elif self._backend == "transformers":
-            encoded = self.tokenizer(texts, add_special_tokens=False)  # type: ignore
-            return [len(token_list) for token_list in encoded["input_ids"]]  # type: ignore
+            encoded = self.tokenizer(texts, add_special_tokens=False)  # type: ignore[operator,call-arg,index,arg-type]
+            return [len(token_list) for token_list in encoded["input_ids"]]  # type: ignore[index]
         elif self._backend == "tokenizers":
-            return [
-                len(t.ids)
-                for t in self.tokenizer.encode_batch(texts, add_special_tokens=False)
-            ]  # type: ignore
+            return [len(t.ids) for t in self.tokenizer.encode_batch(texts, add_special_tokens=False)]  # type: ignore[union-attr,call-arg,arg-type,attr-defined]
         elif self._backend == "callable":
-            return [self.tokenizer(text) for text in texts]  # type: ignore
+            return [self.tokenizer(text) for text in texts]  # type: ignore[operator,misc]
 
         raise ValueError(f"Tokenizer backend {self._backend} not supported.")


### PR DESCRIPTION
This pull request makes several improvements to the `src/chonkie/tokenizer.py` file, focusing on better support for custom tokenizers and code readability. The most important changes are the addition of a new backend type for custom tokenizers and the refactoring of several methods for improved clarity.

**Custom tokenizer support:**

* Added a check in the `_get_backend` method to recognize and return `"chonkie"` as the backend when a custom `Tokenizer` instance is used.

**Code readability and formatting:**

* Reformatted warning messages and exception raising in several methods (`_load_tokenizer`, `encode`, `decode_batch`, `count_tokens_batch`) to use multi-line strings, improving code readability. [[1]](diffhunk://#diff-13ca37b4e926264b8b797d164227c6da379bd71d40fff7a86fab1454dd6b1913L377-R379) [[2]](diffhunk://#diff-13ca37b4e926264b8b797d164227c6da379bd71d40fff7a86fab1454dd6b1913L432-R441) [[3]](diffhunk://#diff-13ca37b4e926264b8b797d164227c6da379bd71d40fff7a86fab1454dd6b1913L516-R527) [[4]](diffhunk://#diff-13ca37b4e926264b8b797d164227c6da379bd71d40fff7a86fab1454dd6b1913L538-R563)