### PR TITLE
Feat: Add `ByteTokenizer`

### DIFF
--- a/src/chonkie/__init__.py
+++ b/src/chonkie/__init__.py
@@ -72,6 +72,7 @@ from .refinery import (
 )
 from .tokenizer import (
     AutoTokenizer,
+    ByteTokenizer,
     CharacterTokenizer,
     Tokenizer,
     TokenizerProtocol,

--- a/src/chonkie/tokenizer.py
+++ b/src/chonkie/tokenizer.py
@@ -309,6 +309,67 @@ class WordTokenizer(Tokenizer):
         return len(self.tokenize(text))
 
 
+class ByteTokenizer(Tokenizer):
+    """Byte-based tokenizer that operates on UTF-8 encoded bytes."""
+
+    def __repr__(self) -> str:
+        """Return a string representation of the ByteTokenizer."""
+        return f"ByteTokenizer(vocab_size={len(self.vocab)})"
+
+    def tokenize(self, text: str) -> Sequence[int]:
+        """Tokenize text into individual bytes.
+
+        Args:
+            text (str): The text to tokenize.
+
+        Returns:
+            List of byte values
+
+        """
+        return list(text.encode("utf-8"))
+
+    def encode(self, text: str) -> Sequence[int]:
+        """Encode the given text into byte tokens.
+
+        Args:
+            text (str): The text to encode.
+
+        Returns:
+            Encoded sequence of byte values
+
+        """
+        return list(text.encode("utf-8"))
+
+    def decode(self, tokens: Sequence[int]) -> str:
+        """Decode byte tokens back into text.
+
+        Args:
+            tokens (Sequence[int]): The byte tokens to decode.
+
+        Returns:
+            Decoded text
+
+        """
+        try:
+            return bytes(tokens).decode("utf-8")
+        except Exception as e:
+            raise ValueError(
+                f"Decoding failed. Tokens: {tokens} cannot be decoded as UTF-8."
+            ) from e
+
+    def count_tokens(self, text: str) -> int:
+        """Count the number of byte tokens in the given text.
+
+        Args:
+            text (str): The text to count tokens in.
+
+        Returns:
+            Number of byte tokens
+
+        """
+        return len(text.encode("utf-8"))
+
+
 class AutoTokenizer:
     """Auto-loading tokenizer interface for Chonkie.
 
@@ -338,6 +399,7 @@ class AutoTokenizer:
     ) -> Union[
         CharacterTokenizer,
         WordTokenizer,
+        ByteTokenizer,
         "tokenizers.Tokenizer",
         "tiktoken.Encoding",
         "transformers.PreTrainedTokenizer",
@@ -349,6 +411,8 @@ class AutoTokenizer:
             return CharacterTokenizer()
         elif tokenizer == "word":
             return WordTokenizer()
+        elif tokenizer == "byte":
+            return ByteTokenizer()
 
         # Try tokenizers first
         if importlib.util.find_spec("tokenizers") is not None:


### PR DESCRIPTION
This pull request adds a new `ByteTokenizer` to the `chonkie` tokenization library, providing byte-level tokenization support for UTF-8 encoded text. It integrates the new tokenizer into the main API, updates the auto-loading logic, and introduces comprehensive tests to ensure correct functionality and edge case coverage.

### ByteTokenizer implementation and integration

* Introduced the `ByteTokenizer` class in `src/chonkie/tokenizer.py`, supporting byte-level tokenization, encoding, decoding, token counting, and error handling for invalid UTF-8 sequences. (`[src/chonkie/tokenizer.pyR312-R372](diffhunk://#diff-13ca37b4e926264b8b797d164227c6da379bd71d40fff7a86fab1454dd6b1913R312-R372)`)
* Registered `ByteTokenizer` in the main `chonkie` package import (`src/chonkie/__init__.py`) and added support for it in the `AutoTokenizer` loader and backend detection logic. (`[[1]](diffhunk://#diff-44a557df57b150a7b71a0b691e66e501f00f8983cc9c66dee9309aaf738bd408R75)`, `[[2]](diffhunk://#diff-13ca37b4e926264b8b797d164227c6da379bd71d40fff7a86fab1454dd6b1913R402)`, `[[3]](diffhunk://#diff-13ca37b4e926264b8b797d164227c6da379bd71d40fff7a86fab1454dd6b1913R414-R415)`)

### Testing and validation

* Added extensive unit tests for `ByteTokenizer` in `tests/test_tokenizer.py`, covering initialization, encoding/decoding, unicode support, batch operations, error cases, and consistency with other tokenizers. (`[tests/test_tokenizer.pyR520-R641](diffhunk://#diff-21366b599c57ca8ad798657d2f6a1d7e2c479ba849513f67af3f7a844fb271a7R520-R641)`)
* Updated test fixtures and edge case tests to include `ByteTokenizer`, ensuring it is properly handled throughout the test suite. (`[[1]](diffhunk://#diff-21366b599c57ca8ad798657d2f6a1d7e2c479ba849513f67af3f7a844fb271a7R71-R76)`, `[[2]](diffhunk://#diff-21366b599c57ca8ad798657d2f6a1d7e2c479ba849513f67af3f7a844fb271a7R828-R831)`, `[[3]](diffhunk://#diff-21366b599c57ca8ad798657d2f6a1d7e2c479ba849513f67af3f7a844fb271a7R860-R863)`, `[[4]](diffhunk://#diff-21366b599c57ca8ad798657d2f6a1d7e2c479ba849513f67af3f7a844fb271a7R1132-R1173)`, `[[5]](diffhunk://#diff-21366b599c57ca8ad798657d2f6a1d7e2c479ba849513f67af3f7a844fb271a7R1202)`, `[[6]](diffhunk://#diff-21366b599c57ca8ad798657d2f6a1d7e2c479ba849513f67af3f7a844fb271a7R1217-R1221)`)