### PR TITLE
Fix: Add ability to wrap AutoTokenizer in another AutoTokenizer instance

### DIFF
--- a/src/chonkie/tokenizer.py
+++ b/src/chonkie/tokenizer.py
@@ -387,12 +387,15 @@ class AutoTokenizer:
 
     def __init__(self, tokenizer: Union[str, Callable, Any] = "character"):
         """Initialize the AutoTokenizer with a specified tokenizer."""
-        if isinstance(tokenizer, str):
+        if isinstance(tokenizer, AutoTokenizer):
+            self.tokenizer = tokenizer.tokenizer  # type: ignore[has-type]
+            self._backend = tokenizer._backend  # type: ignore[has-type]
+        elif isinstance(tokenizer, str):
             self.tokenizer = self._load_tokenizer(tokenizer)
+            self._backend = self._get_backend()
         else:
             self.tokenizer = tokenizer
-
-        self._backend = self._get_backend()
+            self._backend = self._get_backend()
 
     def _load_tokenizer(
         self, tokenizer: str

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -1220,15 +1220,36 @@ def test_tokenizer_decode_batch_chonkie_path() -> None:
     assert byte_decoded == texts
 
 
+def test_autotokenizer_wrapping() -> None:
+    """Test that AutoTokenizer correctly unwraps when passed another AutoTokenizer."""
+    # Create an AutoTokenizer
+    tokenizer1 = AutoTokenizer("byte")
+    assert tokenizer1._backend == "chonkie"
+    assert isinstance(tokenizer1.tokenizer, ByteTokenizer)
+
+    # Wrap it in another AutoTokenizer (this happens in chunkers)
+    tokenizer2 = AutoTokenizer(tokenizer1)
+    assert tokenizer2._backend == "chonkie"
+    assert isinstance(tokenizer2.tokenizer, ByteTokenizer)
+
+    # They should reference the same underlying tokenizer
+    assert tokenizer2.tokenizer is tokenizer1.tokenizer
+
+    # Test that it still works correctly
+    text = "Hello, world!"
+    assert tokenizer1.encode(text) == tokenizer2.encode(text)
+    assert tokenizer1.count_tokens(text) == tokenizer2.count_tokens(text)
+
+
 def test_tokenizer_base_repr_method() -> None:
     """Test the __repr__ method in BaseTokenizer."""
     char_tokenizer = CharacterTokenizer()
     word_tokenizer = WordTokenizer()
-    
+
     # Test that repr includes vocab size
     char_repr = repr(char_tokenizer)
     word_repr = repr(word_tokenizer)
-    
+
     assert "CharacterTokenizer" in char_repr
     assert "WordTokenizer" in word_repr
     assert "vocab_size=" in char_repr


### PR DESCRIPTION
This pull request improves the usability and robustness of the `AutoTokenizer` class in `src/chonkie/tokenizer.py`, specifically making it safer and more predictable to wrap an existing `AutoTokenizer` instance. It also adds a dedicated test to verify the new behavior.

**AutoTokenizer enhancements:**

* Updated the `AutoTokenizer.__init__` method to support being initialized with another `AutoTokenizer` instance, ensuring the underlying tokenizer and backend are correctly preserved and referenced.

**Testing improvements:**

* Added a new test `test_autotokenizer_wrapping` to `tests/test_tokenizer.py` to confirm that wrapping an `AutoTokenizer` with another `AutoTokenizer` maintains the correct backend and tokenizer references, and that encoding/counting tokens continues to work as expected.