### PR TITLE
chore: fix mypy typecheck

### DIFF
--- a/src/chonkie/chef/text.py
+++ b/src/chonkie/chef/text.py
@@ -55,10 +55,10 @@ class TextChef(BaseChef):
         """
         return [self.process(path) for path in paths]
 
-    def __call__(
+    def __call__(  # type: ignore[override]
         self,
         path: Union[str, Path, list[str], list[Path]],
-    ) -> Union[Document, list[Document]]:  # type: ignore[override]
+    ) -> Union[Document, list[Document]]:
         """Process the text data from given file(s).
 
         Args:

--- a/src/chonkie/chunker/late.py
+++ b/src/chonkie/chunker/late.py
@@ -76,8 +76,8 @@ class LateChunker(RecursiveChunker):
         self._use_multiprocessing = False
 
     @classmethod
-    def from_recipe(
-        cls,  # type: ignore[override]
+    def from_recipe(  # type: ignore[override]
+        cls,
         name: Optional[str] = "default",
         lang: Optional[str] = "en",
         path: Optional[str] = None,

--- a/src/chonkie/chunker/neural.py
+++ b/src/chonkie/chunker/neural.py
@@ -6,7 +6,7 @@ It trains an encoder style model on the task of token-classification (think: NER
 """
 
 import importlib.util as importutil
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import Any, Optional, Union
 
 from chonkie.logger import get_logger
 from chonkie.pipeline import chunker
@@ -15,20 +15,6 @@ from chonkie.types import Chunk
 from .base import BaseChunker
 
 logger = get_logger(__name__)
-
-if TYPE_CHECKING:
-    try:
-        from transformers import PreTrainedTokenizerFast, pipeline
-    except ImportError:
-
-        class PreTrainedTokenizerFast:  # type: ignore
-            """Stub class for transformers PreTrainedTokenizerFast when not available."""
-
-            pass
-
-        def pipeline(*args, **kwargs):  # type: ignore
-            """Stub function for transformers pipeline when not available."""
-            pass
 
 # TODO: Add a check to see if the model is supported
 
@@ -89,9 +75,17 @@ class NeuralChunker(BaseChunker):
           stride: The stride to use for the chunker.
 
         """
-        # Lazily load the dependencies
-        self._import_dependencies()
-
+        try:
+            from transformers import (
+                AutoModelForTokenClassification,
+                AutoTokenizer,
+                PreTrainedTokenizerFast,
+                pipeline,
+            )
+        except ImportError as e:
+            raise ImportError(
+                "transformers is not installed. Please install it with `pip install chonkie[neural]`.",
+            ) from e
         # Initialize the tokenizer to pass in to the parent class
         try:
             if isinstance(tokenizer, str):
@@ -120,9 +114,8 @@ class NeuralChunker(BaseChunker):
                     )
                 # Initialize the model
                 self.model = AutoModelForTokenClassification.from_pretrained(
-                    model,
-                    device_map=device_map,
-                )  # type: ignore
+                    model, device_map=device_map
+                )
                 # Set the stride
                 stride = self.SUPPORTED_MODEL_STRIDES[model] if stride is None else stride
             elif model is not None and "transformers" in str(type(model)):
@@ -159,25 +152,6 @@ class NeuralChunker(BaseChunker):
     def _is_available(self) -> bool:
         """Check if the dependencies are installed."""
         return importutil.find_spec("transformers") is not None
-
-    def _import_dependencies(self) -> None:
-        """Import the dependencies."""
-        if self._is_available():
-            global \
-                AutoTokenizer, \
-                AutoModelForTokenClassification, \
-                pipeline, \
-                PreTrainedTokenizerFast
-            from transformers import (
-                AutoModelForTokenClassification,
-                AutoTokenizer,
-                PreTrainedTokenizerFast,
-                pipeline,
-            )
-        else:
-            raise ImportError(
-                "transformers is not installed. Please install it with `pip install chonkie[neural]`.",
-            )
 
     def _get_splits(self, response: list[dict[str, Any]], text: str) -> list[str]:
         """Get the text splits from the model."""

--- a/src/chonkie/embeddings/sentence_transformer.py
+++ b/src/chonkie/embeddings/sentence_transformer.py
@@ -96,11 +96,11 @@ class SentenceTransformerEmbeddings(BaseEmbeddings):
             token_embeddings_raw = self.model.encode(split_texts, output_value="token_embeddings")
         except KeyError:
             # Fallback: use sentence embeddings for each split if token_embeddings not available
-            token_embeddings_raw = self.model.encode(split_texts, convert_to_numpy=True)
             # Ensure all fallback embeddings are np.ndarray before expanding dims
             token_embeddings_raw = [
-                np.expand_dims(np.array(emb), axis=0) for emb in token_embeddings_raw
-            ]  # type: ignore
+                np.expand_dims(np.array(emb), axis=0)  # type: ignore
+                for emb in self.model.encode(split_texts, convert_to_numpy=True)
+            ]
 
         # Ensure all embeddings are numpy arrays
         token_embeddings: list[np.ndarray] = []

--- a/src/chonkie/handshakes/milvus.py
+++ b/src/chonkie/handshakes/milvus.py
@@ -2,7 +2,6 @@
 
 import importlib.util
 from typing import (
-    TYPE_CHECKING,
     Any,
     Literal,
     Optional,
@@ -19,14 +18,6 @@ from .base import BaseHandshake
 from .utils import generate_random_collection_name
 
 logger = get_logger(__name__)
-
-if TYPE_CHECKING:
-    from pymilvus import (
-        Collection,
-        CollectionSchema,
-        DataType,
-        FieldSchema,
-    )
 
 
 class MilvusHandshake(BaseHandshake):
@@ -76,15 +67,21 @@ class MilvusHandshake(BaseHandshake):
             **kwargs: Additional keyword arguments for future use.
 
         """
-        self._import_dependencies()
         super().__init__()
         self.alias = alias
+
+        try:
+            import pymilvus
+        except ImportError as e:
+            raise ImportError(
+                "Milvus is not installed. Please install it with `pip install chonkie[milvus]`.",
+            ) from e
 
         # 1. Establish connection using the ORM's global connection manager
         if client is not None:
             self.client = client
         else:
-            self.client = MilvusClient(
+            self.client = pymilvus.MilvusClient(
                 uri=uri,
                 host=host,
                 port=port,
@@ -95,7 +92,7 @@ class MilvusHandshake(BaseHandshake):
             )  # type: ignore
         # Always connect using ORM before any collection operations
         try:
-            connections.connect(
+            pymilvus.connections.connect(
                 uri=uri,
                 host=host,
                 port=port,
@@ -128,36 +125,8 @@ class MilvusHandshake(BaseHandshake):
         if not self.client.has_collection(self.collection_name):
             self._create_collection_with_schema()
 
-        self.collection = Collection(self.collection_name)  # type: ignore
+        self.collection = pymilvus.Collection(self.collection_name)  # type: ignore
         self.collection.load()
-
-    def _import_dependencies(self) -> None:
-        """Lazy import the dependencies."""
-        if self._is_available():
-            global \
-                Collection, \
-                CollectionSchema, \
-                DataType, \
-                FieldSchema, \
-                connections, \
-                utility, \
-                ConnectionNotExistException, \
-                MilvusClient
-            from pymilvus import (
-                Collection,
-                CollectionSchema,
-                DataType,
-                FieldSchema,
-                MilvusClient,
-                connections,
-                utility,
-            )
-            from pymilvus.exceptions import ConnectionNotExistException
-        else:
-            raise ImportError(
-                "Milvus is not installed. "
-                + "Please install it with `pip install chonkie[milvus]`.",
-            )
 
     def _is_available(self) -> bool:
         """Check if the dependencies are installed."""
@@ -166,6 +135,8 @@ class MilvusHandshake(BaseHandshake):
     def _create_collection_with_schema(self) -> None:
         """Create a new collection with a predefined schema and index."""
         # Define fields: pk, text, metadata, and the vector embedding
+        from pymilvus import Collection, CollectionSchema, DataType, FieldSchema
+
         fields = [
             FieldSchema(name="pk", dtype=DataType.INT64, is_primary=True, auto_id=True),  # type: ignore
             FieldSchema(name="text", dtype=DataType.VARCHAR, max_length=65_535),  # type: ignore


### PR DESCRIPTION
This involved either moving `# type: ignore` comments around (some had jostled out of place in #410 so Mypy wouldn't honor them), or fixing up late-import hacks so Mypy could understand what was going on. (Only did it for the modules that currently failed; will do it everywhere next.)