### PR TITLE
perf: cache all HF Hub requests during test run

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,6 +170,7 @@ dev = [
     "tabulate",
     "openpyxl",
     "uv>=0.9.18",
+    "requests-cache>=1.2.1",
 ]
 
 [dependency-groups]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,44 @@
 """Pytest configuration."""
 
+import logging
 import os
+
+import pytest
+import requests
+
+logger = logging.getLogger(__name__)
 
 
 def pytest_configure() -> None:
     """Global pytest configuration."""
     os.environ["CHONKIE_LOG"] = "unconfigured"
+
+
+@pytest.fixture(autouse=True, scope="session")
+def configure_hf_session(tmp_path_factory):
+    """Configure a caching HTTP session, scoped to the test run, to avoid redundant network calls during tests."""
+    try:
+        from huggingface_hub import configure_http_backend
+    except ImportError:  # HF_Hub not installed, so no need to configure anything
+        return
+
+    try:
+        import requests_cache
+
+        requests_cache_db = tmp_path_factory.mktemp("cache") / "hf_requests_cache"
+
+        def _construct_session() -> requests.Session:
+            return requests_cache.CachedSession(
+                requests_cache_db,
+                allowable_methods=["GET", "POST", "HEAD"],
+                # Only cache typical success/redirect/known-not-found responses.
+                # Error responses (4xx/5xx other than 404) are intentionally not cached
+                # so that transient or environment-specific failures are not persisted
+                # across tests within a session.
+                allowable_codes=[200, 302, 307, 404],
+            )
+
+        configure_http_backend(_construct_session)
+        logger.info("Configured HF Hub HTTP session with requests_cache at %s", requests_cache_db)
+    except ImportError:  # Failed to import requests_cache, I guess
+        pass

--- a/uv.lock
+++ b/uv.lock
@@ -398,6 +398,20 @@ wheels = [
 ]
 
 [[package]]
+name = "cattrs"
+version = "25.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6e/00/2432bb2d445b39b5407f0a90e01b9a271475eea7caf913d7a86bcb956385/cattrs-25.3.0.tar.gz", hash = "sha256:1ac88d9e5eda10436c4517e390a4142d88638fe682c436c93db7ce4a277b884a", size = 509321, upload-time = "2025-10-07T12:26:08.737Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d8/2b/a40e1488fdfa02d3f9a653a61a5935ea08b3c2225ee818db6a76c7ba9695/cattrs-25.3.0-py3-none-any.whl", hash = "sha256:9896e84e0a5bf723bc7b4b68f4481785367ce07a8a02e7e9ee6eb2819bc306ff", size = 70738, upload-time = "2025-10-07T12:26:06.603Z" },
+]
+
+[[package]]
 name = "cerebras-cloud-sdk"
 version = "1.64.1"
 source = { registry = "https://pypi.org/simple" }
@@ -571,7 +585,7 @@ wheels = [
 
 [[package]]
 name = "chonkie"
-version = "1.5.5"
+version = "1.5.6"
 source = { editable = "." }
 dependencies = [
     { name = "chonkie-core" },
@@ -661,6 +675,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-xdist" },
+    { name = "requests-cache" },
     { name = "ruff" },
     { name = "tabulate" },
     { name = "transformers" },
@@ -830,6 +845,7 @@ requires-dist = [
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=2.5.0" },
     { name = "qdrant-client", marker = "extra == 'all'", specifier = ">=1.0.0" },
     { name = "qdrant-client", marker = "extra == 'qdrant'", specifier = ">=1.0.0" },
+    { name = "requests-cache", marker = "extra == 'dev'", specifier = ">=1.2.1" },
     { name = "rich", marker = "extra == 'all'", specifier = ">=13.0.0" },
     { name = "rich", marker = "extra == 'viz'", specifier = ">=13.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.13.3" },
@@ -3402,6 +3418,15 @@ wheels = [
 ]
 
 [[package]]
+name = "platformdirs"
+version = "4.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cf/86/0248f086a84f01b37aaec0fa567b397df1a119f73c16f6c7a9aac73ea309/platformdirs-4.5.1.tar.gz", hash = "sha256:61d5cdcc6065745cdd94f0f878977f8de9437be93de97c1c12f853c9c0cdcbda", size = 21715, upload-time = "2025-12-05T13:52:58.638Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/28/3bfe2fa5a7b9c46fe7e13c97bda14c895fb10fa2ebf1d0abb90e0cea7ee1/platformdirs-4.5.1-py3-none-any.whl", hash = "sha256:d03afa3963c806a9bed9d5125c8f4cb2fdaf74a55ab60e5d59b3fde758104d31", size = 18731, upload-time = "2025-12-05T13:52:56.823Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4444,6 +4469,23 @@ wheels = [
 ]
 
 [[package]]
+name = "requests-cache"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "cattrs" },
+    { name = "platformdirs" },
+    { name = "requests" },
+    { name = "url-normalize" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a4/6c/deaf1a9462ce8b6a9ac0ee3603d9ba32917be8e48c8f6799770d5418c3cb/requests_cache-1.3.0.tar.gz", hash = "sha256:070e357ccef11a300ccef4294a85de1ab265833c5d9c9538b26cd7ba4085d54a", size = 97720, upload-time = "2026-02-02T23:17:33.245Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/3f/dfa42bb16be96d53351aa151cb1e39fcaafe6cda01389c530a2ec809ef8a/requests_cache-1.3.0-py3-none-any.whl", hash = "sha256:f09f27bbf100c250886acf13a9db35b53cf2852fddd71977b47c71ea7d90dbba", size = 69626, upload-time = "2026-02-02T23:17:31.718Z" },
+]
+
+[[package]]
 name = "requests-oauthlib"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -5322,6 +5364,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/95/32/1a225d6164441be760d75c2c42e2780dc0873fe382da3e98a2e1e48361e5/tzdata-2025.2.tar.gz", hash = "sha256:b60a638fcc0daffadf82fe0f57e53d06bdec2f36c4df66280ae79bce6bd6f2b9", size = 196380, upload-time = "2025-03-23T13:54:43.652Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5c/23/c7abc0ca0a1526a0774eca151daeb8de62ec457e77262b66b359c3c7679e/tzdata-2025.2-py2.py3-none-any.whl", hash = "sha256:1a403fada01ff9221ca8044d701868fa132215d84beb92242d9acd2147f667a8", size = 347839, upload-time = "2025-03-23T13:54:41.845Z" },
+]
+
+[[package]]
+name = "url-normalize"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/80/31/febb777441e5fcdaacb4522316bf2a527c44551430a4873b052d545e3279/url_normalize-2.2.1.tar.gz", hash = "sha256:74a540a3b6eba1d95bdc610c24f2c0141639f3ba903501e61a52a8730247ff37", size = 18846, upload-time = "2025-04-26T20:37:58.553Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/d9/5ec15501b675f7bc07c5d16aa70d8d778b12375686b6efd47656efdc67cd/url_normalize-2.2.1-py3-none-any.whl", hash = "sha256:3deb687587dc91f7b25c9ae5162ffc0f057ae85d22b1e15cf5698311247f567b", size = 14728, upload-time = "2025-04-26T20:37:57.217Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
I was running tests with `--log-cli-level=DEBUG` and noticed `huggingface_hub` was making a whole bunch of repeated similar `HEAD` etc. requests to HF Hub (which makes sense, when e.g. each test case builds a new `SentenceTransformers` instance, etc.), just to figure out if the models (even if cached) are the latest versions or if they need updating.

I figured we don't expect (non-transient-error) HF responses to change over a test run, so this adds `requests-cache` as a dev dependency and hooks it up with an autouse fixture.

On my machine, the speedup is a pretty impressive (though less so if you run with `pytest-xdist`) 3.65x.

| Branch | pytest time | pytest-xdist time |
|--------|--------|--------|
| hf-cache-in-tests | 3 failed, 951 passed, 55 skipped, 26 warnings in 52.49s | 25.26s |
| main | 3 failed, 951 passed, 55 skipped, 26 warnings in 190.26s | 31.67s |