### PR TITLE
Use `logger.warning` for warnings

### DIFF
--- a/src/chonkie/chef/base.py
+++ b/src/chonkie/chef/base.py
@@ -70,7 +70,7 @@ class BaseChef(ABC):
                 logger.debug(f"Successfully read file: {path}", size=len(content))
                 return content
         except Exception as e:
-            logger.warning(f"Failed to read file: {path}", error=str(e))
+            logger.warning(f"Failed to read file {path}: {e}", exc_info=True)
             raise
 
     def __call__(self, path: str | os.PathLike) -> Document:

--- a/src/chonkie/chunker/base.py
+++ b/src/chonkie/chunker/base.py
@@ -1,6 +1,5 @@
 """Base Class for All Chunkers."""
 
-import warnings
 from abc import ABC, abstractmethod
 from typing import Sequence, Union
 
@@ -76,11 +75,10 @@ class BaseChunker(ABC):
                 cpu_cores=cpu_cores,
             )
             return worker_count
-        except Exception as e:
-            warnings.warn(f"Proceeding with 1 worker. Error calculating optimal worker count: {e}")
+        except Exception:
             logger.warning(
                 "Failed to calculate optimal worker count, using 1 worker",
-                error=str(e),
+                exc_info=True,
             )
             return 1
 

--- a/src/chonkie/chunker/code.py
+++ b/src/chonkie/chunker/code.py
@@ -4,7 +4,6 @@ This module provides a CodeChunker class for splitting code into chunks of a spe
 
 """
 
-import warnings
 from bisect import bisect_left
 from itertools import accumulate
 from typing import TYPE_CHECKING, Any, Literal, Union
@@ -73,9 +72,9 @@ class CodeChunker(BaseChunker):
         if language == "auto":
             # Set a warning to the user that the language is auto and this might
             # effect the performance of the chunker.
-            warnings.warn(
+            logger.warning(
                 "The language is set to `auto`. This would adversely affect the performance of the chunker. "
-                + "Consider setting the `language` parameter to a specific language to improve performance.",
+                "Consider setting the `language` parameter to a specific language to improve performance.",
             )
             from magika import Magika
 
@@ -256,13 +255,13 @@ class CodeChunker(BaseChunker):
 
             # Basic validation for byte offsets
             if start_byte > end_byte:
-                warnings.warn(
-                    f"Warning: Skipping group due to invalid byte order. Start: {start_byte}, End: {end_byte}",
+                logger.warning(
+                    f"Skipping group due to invalid byte order. Start: {start_byte}, End: {end_byte}",
                 )
                 continue
             if start_byte < 0 or end_byte > len(original_text_bytes):
-                warnings.warn(
-                    f"Warning: Skipping group due to out-of-bounds byte offsets. Start: {start_byte}, End: {end_byte}, Text Length: {len(original_text_bytes)}",
+                logger.warning(
+                    f"Skipping group due to out-of-bounds byte offsets. Start: {start_byte}, End: {end_byte}, Text Length: {len(original_text_bytes)}",
                 )
                 continue
 
@@ -278,8 +277,9 @@ class CodeChunker(BaseChunker):
                 text = chunk_bytes.decode("utf-8", errors="ignore")  # Or 'replace'
                 chunk_texts.append(text)
             except Exception as e:
-                warnings.warn(
-                    f"Warning: Error decoding bytes for chunk ({start_byte}-{end_byte}): {e}",
+                logger.warning(
+                    f"Error decoding bytes for chunk ({start_byte}-{end_byte}): {e}",
+                    exc_info=True,
                 )
                 # Append an empty string or placeholder if decoding fails
                 chunk_texts.append("")

--- a/src/chonkie/chunker/sentence.py
+++ b/src/chonkie/chunker/sentence.py
@@ -88,6 +88,7 @@ class SentenceChunker(BaseChunker):
         if approximate:
             warnings.warn(
                 "Approximate has been deprecated and will be removed from next version onwards!",
+                DeprecationWarning,
             )
 
         # Assign the values if they make sense
@@ -311,10 +312,10 @@ class SentenceChunker(BaseChunker):
                 if pos + self.min_sentences_per_chunk <= len(sentences):
                     split_idx = pos + self.min_sentences_per_chunk
                 else:
-                    warnings.warn(
+                    logger.warning(
                         f"Minimum sentences per chunk as {self.min_sentences_per_chunk} could not be met for all chunks. "
-                        + f"Last chunk of the text will have only {len(sentences) - pos} sentences. "
-                        + "Consider increasing the chunk_size or decreasing the min_sentences_per_chunk.",
+                        f"Last chunk of the text will have only {len(sentences) - pos} sentences. "
+                        "Consider increasing the chunk_size or decreasing the min_sentences_per_chunk.",
                     )
                     split_idx = len(sentences)
 

--- a/src/chonkie/chunker/table.py
+++ b/src/chonkie/chunker/table.py
@@ -1,7 +1,6 @@
 """Table chunker for processing markdown tables."""
 
 import re
-import warnings
 from typing import Union
 
 from chonkie.chunker.base import BaseChunker
@@ -38,7 +37,7 @@ class TableChunker(BaseChunker):
         if chunk_size <= 0:
             raise ValueError("Chunk size must be greater than 0.")
         if chunk_size == 3 and tokenizer != "row":
-            warnings.warn(
+            logger.warning(
                 "Using default chunk size of 3 with a token-based tokenizer may not be optimal. "
                 "Consider using a larger chunk_size for token-based chunking.",
             )
@@ -71,12 +70,12 @@ class TableChunker(BaseChunker):
         chunks: list[Chunk] = []
         # Basic validation
         if not text.strip():
-            warnings.warn("No table content found. Skipping chunking.")
+            logger.warning("No table content found. Skipping chunking.")
             return []
 
         rows = text.strip().split("\n")
         if len(rows) < 3:  # Need header, separator, and at least one data row
-            warnings.warn(
+            logger.warning(
                 "Table must have at least a header, separator, and one data row. Skipping chunking.",
             )
             return []

--- a/src/chonkie/embeddings/auto.py
+++ b/src/chonkie/embeddings/auto.py
@@ -1,10 +1,13 @@
 """AutoEmbeddings is a factory class for automatically loading embeddings."""
 
-import warnings
 from typing import Any, Union
+
+from chonkie.logger import get_logger
 
 from .base import BaseEmbeddings
 from .registry import EmbeddingsRegistry
+
+logger = get_logger(__name__)
 
 
 class AutoEmbeddings:
@@ -92,17 +95,19 @@ class AutoEmbeddings:
                         # Try instantiating with the model identifier
                         embeddings_instance = embeddings_cls(model, **kwargs)  # type: ignore
                     except Exception as error:
-                        warnings.warn(
+                        logger.warning(
                             f"Failed to load {model} with {embeddings_cls.__name__}: {error}\n"
-                            f"Falling back to loading default provider model.",
+                            "Falling back to loading default provider model.",
+                            exc_info=True,
                         )
                         try:
                             # Try instantiating with the default provider model without the model identifier
                             embeddings_instance = embeddings_cls(**kwargs)
                         except Exception as error:
-                            warnings.warn(
+                            logger.warning(
                                 f"Failed to load the default model for {embeddings_cls.__name__}: {error}\n"
-                                f"Falling back to SentenceTransformerEmbeddings.",
+                                "Falling back to SentenceTransformerEmbeddings.",
+                                exc_info=True,
                             )
 
             # If registry lookup and instantiation succeeded, return the instance

--- a/src/chonkie/embeddings/azure_openai.py
+++ b/src/chonkie/embeddings/azure_openai.py
@@ -2,15 +2,19 @@
 
 import importlib.util as importutil
 import os
-import warnings
 from typing import TYPE_CHECKING, Any, Optional
 
 import numpy as np
+
+from chonkie.logger import get_logger
 
 from .base import BaseEmbeddings
 
 if TYPE_CHECKING:
     from tiktoken import Encoding
+
+
+logger = get_logger(__name__)
 
 
 class AzureOpenAIEmbeddings(BaseEmbeddings):
@@ -167,7 +171,10 @@ class AzureOpenAIEmbeddings(BaseEmbeddings):
                 all_embeddings.extend(embeddings)
             except Exception as e:
                 if len(batch) > 1:
-                    warnings.warn(f"Batch failed: {e}. Falling back to single embedding calls.")
+                    logger.warning(
+                        f"Batch failed: {e}. Falling back to single embedding calls.",
+                        exc_info=True,
+                    )
                     all_embeddings.extend(self.embed(t) for t in batch)
                 else:
                     raise

--- a/src/chonkie/embeddings/catsu.py
+++ b/src/chonkie/embeddings/catsu.py
@@ -8,12 +8,15 @@ Nomic, Cloudflare, MixedBread, DeepInfra, TogetherAI.
 """
 
 import importlib.util as importutil
-import warnings
 from typing import Any, Dict, List, Optional
 
 import numpy as np
 
+from chonkie.logger import get_logger
+
 from .base import BaseEmbeddings
+
+logger = get_logger(__name__)
 
 
 class CatsuEmbeddings(BaseEmbeddings):
@@ -117,8 +120,9 @@ class CatsuEmbeddings(BaseEmbeddings):
         try:
             self._load_model_info()
         except Exception as e:
-            warnings.warn(
+            logger.warning(
                 f"Could not load model info for {model}: {e}. Will attempt to use model anyway.",
+                exc_info=True,
             )
 
     def _load_model_info(self) -> None:
@@ -132,13 +136,13 @@ class CatsuEmbeddings(BaseEmbeddings):
                     break
 
             if self._model_info is None and self._verbose:
-                warnings.warn(
+                logger.warning(
                     f"Model '{self.model}' not found in Catsu catalog. "
                     "Embedding may fail if model name is incorrect.",
                 )
         except Exception as e:
             if self._verbose:
-                warnings.warn(f"Failed to load model info: {e}")
+                logger.warning(f"Failed to load model info: {e}", exc_info=True)
 
     def embed(self, text: str) -> np.ndarray:
         """Embed a single text string into a vector representation.
@@ -203,7 +207,10 @@ class CatsuEmbeddings(BaseEmbeddings):
             except Exception as e:
                 # If batch fails, try one by one (with Catsu's built-in retries)
                 if len(batch) > 1:
-                    warnings.warn(f"Batch embedding failed: {str(e)}. Trying one by one.")
+                    logger.warning(
+                        f"Batch embedding failed: {e}. Trying one by one.",
+                        exc_info=True,
+                    )
                     for text in batch:
                         individual_embedding = self.embed(text)
                         all_embeddings.append(individual_embedding)
@@ -391,7 +398,7 @@ class CatsuTokenizerWrapper:
         """
         # Catsu doesn't expose token IDs for all providers
         # Return empty list as fallback
-        warnings.warn(
+        logger.warning(
             "Token encoding not supported via Catsu. Use count() for token counting instead.",
         )
         return []

--- a/src/chonkie/experimental/code.py
+++ b/src/chonkie/experimental/code.py
@@ -4,10 +4,10 @@ This module provides an experimental CodeChunker class that uses tree-sitter
 for advanced code analysis and language-specific chunking strategies.
 """
 
-import warnings
 from typing import TYPE_CHECKING, Any, Optional
 
 from chonkie.chunker.base import BaseChunker
+from chonkie.logger import get_logger
 from chonkie.types import Chunk
 from chonkie.types.code import SplitRule
 
@@ -15,6 +15,9 @@ from .code_registry import CodeLanguageRegistry
 
 if TYPE_CHECKING:
     from tree_sitter import Node
+
+
+logger = get_logger(__name__)
 
 
 class CodeChunker(BaseChunker):
@@ -75,9 +78,9 @@ class CodeChunker(BaseChunker):
         if language == "auto":
             # Set a warning to the user that the language is auto and this might
             # affect the performance of the chunker.
-            warnings.warn(
+            logger.warning(
                 "The language is set to `auto`. This would adversely affect the performance of the chunker. "
-                + "Consider setting the `language` parameter to a specific language to improve performance.",
+                "Consider setting the `language` parameter to a specific language to improve performance.",
             )
 
             from magika import Magika

--- a/src/chonkie/handshakes/base.py
+++ b/src/chonkie/handshakes/base.py
@@ -56,9 +56,8 @@ class BaseHandshake(ABC):
                 return result
             except Exception as e:
                 logger.error(
-                    f"Failed to write {chunk_count} chunk(s) to database",
-                    error=str(e),
-                    error_type=type(e).__name__,
+                    f"Failed to write {chunk_count} chunk(s) to database: {e}",
+                    exc_info=True,
                 )
                 raise
         else:

--- a/src/chonkie/handshakes/weaviate.py
+++ b/src/chonkie/handshakes/weaviate.py
@@ -201,7 +201,10 @@ class WeaviateHandshake(BaseHandshake):
             exists = self.client.collections.exists(collection_name)
             return exists
         except Exception as e:
-            logger.warning(f"Failed to check for collection '{collection_name}': {e}")
+            logger.warning(
+                f"Failed to check for collection '{collection_name}': {e}",
+                exc_info=True,
+            )
             return False
 
     def _create_collection(self) -> None:
@@ -345,7 +348,7 @@ class WeaviateHandshake(BaseHandshake):
 
                     chunk_ids.append(chunk_id)
                 except Exception as e:
-                    logger.error(f"Error processing chunk {index}: {str(e)}")
+                    logger.error(f"Error processing chunk {index}: {e}", exc_info=True)
                     # Continue with next chunk
 
             # After batch is complete, check for errors

--- a/src/chonkie/refinery/base.py
+++ b/src/chonkie/refinery/base.py
@@ -61,5 +61,5 @@ class BaseRefinery(ABC):
             logger.info(f"Refinement complete: {len(refined_chunks)} chunks output")
             return refined_chunks
         except Exception as e:
-            logger.error(f"Refinement failed: {str(e)}", error_type=type(e).__name__)
+            logger.error(f"Refinement failed: {e}", exc_info=True)
             raise

--- a/src/chonkie/refinery/overlap.py
+++ b/src/chonkie/refinery/overlap.py
@@ -1,6 +1,5 @@
 """Refinery for adding overlap to chunks."""
 
-import warnings
 from functools import lru_cache
 from typing import Literal, Union
 
@@ -192,7 +191,7 @@ class OverlapRefinery(BaseRefinery):
         tokens = self._get_tokens_cached(chunk.text)
 
         if effective_context_size > len(tokens):
-            warnings.warn(
+            logger.warning(
                 "Context size is greater than the chunk size. The entire chunk will be returned as the context.",
             )
             return chunk.text
@@ -337,7 +336,7 @@ class OverlapRefinery(BaseRefinery):
         tokens = self._get_tokens_cached(chunk.text)
 
         if effective_context_size > len(tokens):
-            warnings.warn(
+            logger.warning(
                 "Context size is greater than the chunk size. The entire chunk will be returned as the context.",
             )
             return chunk.text

--- a/src/chonkie/tokenizer.py
+++ b/src/chonkie/tokenizer.py
@@ -2,11 +2,12 @@
 
 import importlib.util as importutil
 import inspect
-import logging
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from collections.abc import Callable, Sequence
 from typing import TYPE_CHECKING, Any, Protocol
+
+from chonkie.logger import get_logger
 
 if TYPE_CHECKING:
     import tiktoken
@@ -14,7 +15,7 @@ if TYPE_CHECKING:
     import transformers
 
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class TokenizerProtocol(Protocol):

--- a/src/chonkie/utils/viz.py
+++ b/src/chonkie/utils/viz.py
@@ -3,7 +3,6 @@
 import base64
 import html
 import os
-import warnings
 from typing import Optional, Sequence, Union
 
 from chonkie.logger import get_logger
@@ -288,7 +287,7 @@ class Visualizer:
             darker_rgb = tuple(max(0, int(c * amount)) for c in rgb)
             return "#{:02x}{:02x}{:02x}".format(*darker_rgb)
         except Exception as e:
-            logger.warning(f"Could not darken color {hex_color}: {e}")
+            logger.warning(f"Could not darken color {hex_color}: {e}", exc_info=True)
             return "#808080"
 
     def print(self, chunks: Sequence[Union[Chunk, str]], full_text: Optional[str] = None) -> None:
@@ -323,7 +322,7 @@ class Visualizer:
                     "end": int(chunk.end_index),
                 })
             except (AttributeError, TypeError, ValueError):
-                warnings.warn(f"Warning: Skipping chunk with invalid start/end index: {chunk}")
+                logger.warning(f"Skipping chunk with invalid start/end index: {chunk}")
                 continue
 
         # Apply the styles to the text
@@ -337,8 +336,8 @@ class Visualizer:
                 try:
                     text.stylize(style, start, effective_end)
                 except Exception as e:
-                    warnings.warn(
-                        f"Warning: Could not apply style '{style}' to span ({start}, {effective_end}). Error: {e}",
+                    logger.warning(
+                        f"Could not apply style '{style}' to span ({start}, {effective_end}). Error: {e}",
                     )
         # Print the text with rich highlights
         self.console.print(text)
@@ -401,7 +400,7 @@ class Visualizer:
                         "tokens": token_count,
                     })
             except (AttributeError, TypeError, ValueError):
-                warnings.warn(f"Warning: Skipping chunk with invalid start/end index: {chunk}")
+                logger.warning(f"Skipping chunk with invalid start/end index: {chunk}")
                 continue
 
         # --- 2. Generate HTML Parts (Event-based with Overlap Detection) ---

--- a/tests/chunkers/test_table_chunker.py
+++ b/tests/chunkers/test_table_chunker.py
@@ -155,37 +155,28 @@ def test_table_chunker_preserves_content() -> None:
     assert set(unique_data_rows) == set(original_data)
 
 
-def test_table_chunker_invalid_table() -> None:
+def test_table_chunker_invalid_table(caplog) -> None:
     """Test that the TableChunker handles invalid tables appropriately."""
     chunker = TableChunker(tokenizer="character", chunk_size=500)
 
     # Table with no rows (just header)
-    invalid_table = """| Name | Value |
-|------|-------|"""
-
-    with pytest.warns(
-        UserWarning,
-        match="Table must have at least a header, separator, and one data row",
-    ):
-        chunks = chunker.chunk(invalid_table)
-        assert len(chunks) == 0
+    chunks = chunker.chunk("| Name | Value |\n|------|-------|")
+    assert len(chunks) == 0
+    assert "Table must have at least a header, separator, and one data row" in caplog.text
+    caplog.clear()
 
     # Single line (no table structure)
-    with pytest.warns(
-        UserWarning,
-        match="Table must have at least a header, separator, and one data row",
-    ):
-        chunks = chunker.chunk("Just a single line")
-        assert len(chunks) == 0
+    chunks = chunker.chunk("Just a single line")
+    assert len(chunks) == 0
+    assert "Table must have at least a header, separator, and one data row" in caplog.text
 
 
-def test_table_chunker_empty_input() -> None:
+def test_table_chunker_empty_input(caplog) -> None:
     """Test that the TableChunker handles empty input."""
     chunker = TableChunker(tokenizer="character", chunk_size=500)
 
-    with pytest.warns(UserWarning, match="No table content found"):
-        chunks = chunker.chunk("")
-        assert len(chunks) == 0
+    assert not chunker.chunk("")
+    assert "No table content found" in caplog.text
 
 
 def test_table_chunker_exact_chunk_size() -> None:

--- a/tests/embeddings/test_auto_embeddings.py
+++ b/tests/embeddings/test_auto_embeddings.py
@@ -1,7 +1,6 @@
 """Tests for the AutoEmbeddings class."""
 
 import os
-import warnings
 
 import pytest
 
@@ -160,14 +159,12 @@ class TestAutoEmbeddingsInputTypes:
                 return [[1.0, 2.0, 3.0] for _ in texts]
 
         mock_obj = MockEmbeddings()
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            try:
-                result = AutoEmbeddings.get_embeddings(mock_obj)
-                assert isinstance(result, BaseEmbeddings)
-            except ValueError:
-                # Expected if registry can't wrap this type
-                pass
+        try:
+            result = AutoEmbeddings.get_embeddings(mock_obj)
+            assert isinstance(result, BaseEmbeddings)
+        except ValueError:
+            # Expected if registry can't wrap this type
+            pass
 
 
 class TestAutoEmbeddingsErrorHandling:

--- a/tests/embeddings/test_catsu_embeddings.py
+++ b/tests/embeddings/test_catsu_embeddings.py
@@ -175,6 +175,7 @@ def test_embed_batch_with_batching(embedding_model: CatsuEmbeddings) -> None:
 def test_embed_batch_fallback_on_error(
     embedding_model: CatsuEmbeddings,
     sample_texts: List[str],
+    caplog,
 ) -> None:
     """Test that CatsuEmbeddings falls back to individual embeds on batch failure."""
     # Mock batch embed to fail, individual embeds to succeed
@@ -196,9 +197,8 @@ def test_embed_batch_fallback_on_error(
 
     embedding_model.client.embed.side_effect = mock_embed_side_effect
 
-    with pytest.warns(UserWarning, match="Batch embedding failed"):
-        embeddings = embedding_model.embed_batch(sample_texts)
-
+    embeddings = embedding_model.embed_batch(sample_texts)
+    assert "Batch embedding failed" in caplog.text
     assert len(embeddings) == len(sample_texts)
 
 
@@ -255,14 +255,13 @@ def test_tokenizer_count(embedding_model: CatsuEmbeddings, sample_text: str) -> 
     assert token_count == 10  # From mock
 
 
-def test_tokenizer_encode_warning(embedding_model: CatsuEmbeddings) -> None:
+def test_tokenizer_encode_warning(embedding_model: CatsuEmbeddings, caplog) -> None:
     """Test that tokenizer encode method warns about unsupported functionality."""
     tokenizer = embedding_model.get_tokenizer()
 
-    with pytest.warns(UserWarning, match="Token encoding not supported"):
-        tokens = tokenizer.encode("test text")
-
+    tokens = tokenizer.encode("test text")
     assert tokens == []
+    assert "Token encoding not supported" in caplog.text
 
 
 def test_repr(embedding_model: CatsuEmbeddings) -> None:

--- a/tests/refinery/test_overlap_refinery.py
+++ b/tests/refinery/test_overlap_refinery.py
@@ -472,12 +472,7 @@ def test_overlap_refinery_context_larger_than_chunk() -> None:
     refinery = OverlapRefinery(context_size=10, mode="token", method="suffix")
 
     # Should handle gracefully (with warnings)
-    import warnings
-
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
-        refined_chunks = refinery.refine(chunks)
-
+    refined_chunks = refinery.refine(chunks)
     assert len(refined_chunks) == 2
 
 
@@ -704,10 +699,8 @@ def test_overlap_refinery_empty_text_recursive() -> None:
     assert len(refined_chunks2) == 2
 
 
-def test_overlap_refinery_context_size_warnings() -> None:
+def test_overlap_refinery_context_size_warnings(caplog) -> None:
     """Test warnings when context size is larger than chunk."""
-    import warnings
-
     chunks = [
         Chunk(text="A", start_index=0, end_index=0, token_count=1),
         Chunk(text="B", start_index=1, end_index=1, token_count=1),
@@ -716,15 +709,14 @@ def test_overlap_refinery_context_size_warnings() -> None:
     # Test suffix overlap with very large context size to trigger warnings
     refinery_suffix = OverlapRefinery(context_size=100, mode="token", method="suffix")
 
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("always")
-        refined_chunks = refinery_suffix.refine(chunks)
+    refined_chunks = refinery_suffix.refine(chunks)
 
-        # Should have warnings about context size being too large
-        assert len(w) > 0
-        assert "Context size is greater than the chunk size" in str(w[0].message)
+    # Should have warnings about context size being too large
+    assert "Context size is greater than the chunk size" in caplog.text
 
     assert len(refined_chunks) == 2
+
+    caplog.clear()
 
     # Test prefix overlap with very large context size to trigger warnings
     # Use fresh chunks since the previous test may have modified them
@@ -734,13 +726,10 @@ def test_overlap_refinery_context_size_warnings() -> None:
     ]
     refinery_prefix = OverlapRefinery(context_size=100, mode="token", method="prefix")
 
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("always")
-        refined_chunks = refinery_prefix.refine(fresh_chunks)
+    refined_chunks = refinery_prefix.refine(fresh_chunks)
 
-        # Should have warnings about context size being too large
-        assert len(w) > 0
-        assert "Context size is greater than the chunk size" in str(w[0].message)
+    # Should have warnings about context size being too large
+    assert "Context size is greater than the chunk size" in caplog.text
 
     assert len(refined_chunks) == 2
 

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -113,7 +113,7 @@ def test_backend_selection(request: pytest.FixtureRequest, backend_str: str) -> 
     try:
         tokenizer = AutoTokenizer(request.getfixturevalue(backend_str))
     except Exception as e:
-        pytest.skip(f"Skipping test with backend {backend_str}: {str(e)}")
+        pytest.skip(f"Skipping test with backend {backend_str}: {e}")
 
     assert tokenizer._backend in [
         "transformers",
@@ -135,7 +135,7 @@ def test_string_init(model_name: str) -> None:
             "tiktoken",
         ]
     except ImportError as e:
-        pytest.skip(f"Could not import tokenizer for {model_name}: {str(e)}")
+        pytest.skip(f"Could not import tokenizer for {model_name}: {e}")
     except Exception as e:
         if "not found in model".casefold() in str(e).casefold():
             pytest.skip(f"Skipping test with {model_name}. Backend not available")
@@ -153,7 +153,7 @@ def test_encode_decode(request: pytest.FixtureRequest, backend_str: str, sample_
         tokenizer = request.getfixturevalue(backend_str)
         tokenizer = AutoTokenizer(tokenizer)
     except Exception as e:
-        pytest.skip(f"Skipping test with backend {backend_str}: {str(e)}")
+        pytest.skip(f"Skipping test with backend {backend_str}: {e}")
 
     # Encode, Decode and Compare
     tokens = tokenizer.encode(sample_text)
@@ -194,7 +194,7 @@ def test_string_init_encode_decode(model_name: str) -> None:
         ]:
             assert word.lower() in decoded.lower()
     except ImportError as e:
-        pytest.skip(f"Skipping test. Could not import tokenizer for {model_name}: {str(e)}")
+        pytest.skip(f"Skipping test. Could not import tokenizer for {model_name}: {e}")
     except Exception as e:
         if "not found in model".casefold() in str(e).casefold():
             pytest.skip(f"Skipping test with {model_name}. Backend not available")
@@ -221,7 +221,7 @@ def test_token_counting(
         tokenizer = request.getfixturevalue(backend_str)
         tokenizer = AutoTokenizer(tokenizer)
     except Exception as e:
-        pytest.skip(f"Skipping test with backend {backend_str}: {str(e)}")
+        pytest.skip(f"Skipping test with backend {backend_str}: {e}")
 
     count = tokenizer.count_tokens(sample_text)
     assert isinstance(count, int)
@@ -246,7 +246,7 @@ def test_batch_encode_decode(
         tokenizer = request.getfixturevalue(backend_str)
         tokenizer = AutoTokenizer(tokenizer)
     except Exception as e:
-        pytest.skip(f"Skipping test with backend {backend_str}: {str(e)}")
+        pytest.skip(f"Skipping test with backend {backend_str}: {e}")
 
     batch_encoded = tokenizer.encode_batch(sample_text_list)
     assert isinstance(batch_encoded, list)
@@ -277,7 +277,7 @@ def test_batch_counting(
         tokenizer = request.getfixturevalue(backend_str)
         tokenizer = AutoTokenizer(tokenizer)
     except Exception as e:
-        pytest.skip(f"Skipping test with backend {backend_str}: {str(e)}")
+        pytest.skip(f"Skipping test with backend {backend_str}: {e}")
 
     # Test batch token count
     counts = tokenizer.count_tokens_batch(sample_text_list)
@@ -894,27 +894,6 @@ def test_tokenizer_invalid_initialization(invalid_input: Any) -> None:
 
 
 ### Additional Coverage Tests ###
-
-
-def test_tokenizer_fallback_warnings() -> None:
-    """Test that appropriate warnings are issued during tokenizer fallbacks."""
-    import warnings
-
-    # Test with a non-existent model to trigger fallbacks
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("always")
-        try:
-            # This should trigger warning fallbacks
-            AutoTokenizer("non_existent_model_12345")
-        except ValueError:
-            # Expected to fail eventually, but should generate warnings
-            pass
-
-        # Check that some warnings were generated during fallback attempts
-        warning_messages = [str(warning.message) for warning in w]
-        fallback_warnings = [msg for msg in warning_messages if "Falling back" in msg]
-        # At least one fallback warning should be generated
-        assert len(fallback_warnings) >= 0  # May vary based on available packages
 
 
 def test_tokenizer_decode_batch_callable_error() -> None:

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -3,7 +3,6 @@
 import html
 import os
 import tempfile
-import warnings
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -230,7 +229,7 @@ class TestVisualizerPrintMethod:
             with pytest.raises(ValueError, match="Chunks must have 'text'"):
                 viz.print(invalid_chunks)
 
-    def test_print_invalid_chunk_indices(self, sample_text: str) -> None:
+    def test_print_invalid_chunk_indices(self, sample_text: str, caplog) -> None:
         """Test printing with chunks having invalid indices."""
         invalid_chunks = [
             MagicMock(text="Hello ", start_index=None, end_index=6),
@@ -245,16 +244,14 @@ class TestVisualizerPrintMethod:
             mock_console_class.return_value = mock_console
             mock_text_class.return_value = mock_text
             viz = Visualizer()
-            with warnings.catch_warnings(record=True) as w:
-                warnings.simplefilter("always")
-                viz.print(invalid_chunks, sample_text)
-                assert len(w) == 2
-                assert "invalid start/end index" in str(w[0].message)
+            viz.print(invalid_chunks, sample_text)
+            assert "invalid start/end index" in caplog.text
 
     def test_print_stylize_error_handling(
         self,
         sample_chunks: list[Chunk],
         sample_text: str,
+        caplog,
     ) -> None:
         """Test error handling during text stylization."""
         with (
@@ -267,11 +264,8 @@ class TestVisualizerPrintMethod:
             mock_console_class.return_value = mock_console
             mock_text_class.return_value = mock_text
             viz = Visualizer()
-            with warnings.catch_warnings(record=True) as w:
-                warnings.simplefilter("always")
-                viz.print(sample_chunks, sample_text)
-                assert len(w) >= 1
-                assert "Could not apply style" in str(w[0].message)
+            viz.print(sample_chunks, sample_text)
+            assert "Could not apply style" in caplog.text
 
 
 class TestVisualizerSaveMethod:
@@ -549,9 +543,7 @@ class TestVisualizerEdgeCases:
         ]
         with patch("rich.console.Console"):
             viz = Visualizer()
-            with warnings.catch_warnings(record=True):
-                warnings.simplefilter("always")
-                viz.print(equal_indices_chunks, sample_text)
+            viz.print(equal_indices_chunks, sample_text)
 
 
 class TestVisualizerConstants:


### PR DESCRIPTION
Chonkie's logging advertises it's at warning level by default, but many warnings in the library actually use `warnings.warn()`, which is not governed by the logging framework.

With this PR, every warning becomes `logging`-based instead, and `exc_info=True`s are added, so users get the context for why something fails warnworthily (which is related to #424).