### PR TITLE
Fix: Refactor VoyageAIEmbeddings Test case + Bump version to 1.5.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "chonkie"
-version = "1.5.0"
+version = "1.5.1"
 description = "🦛 CHONK your texts with Chonkie ✨ - The no-nonsense chunking library"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/chonkie/__init__.py
+++ b/src/chonkie/__init__.py
@@ -98,6 +98,6 @@ from .utils import (
 )
 
 # This hippo grows with every release 🦛✨~
-__version__ = "1.5.0"
+__version__ = "1.5.1"
 __name__ = "chonkie"
 __author__ = "🦛 Chonkie Inc"

--- a/tests/embeddings/test_auto_embeddings.py
+++ b/tests/embeddings/test_auto_embeddings.py
@@ -8,12 +8,12 @@ import pytest
 from chonkie import AutoEmbeddings
 from chonkie.embeddings.azure_openai import AzureOpenAIEmbeddings
 from chonkie.embeddings.base import BaseEmbeddings
+from chonkie.embeddings.catsu import CatsuEmbeddings
 from chonkie.embeddings.cohere import CohereEmbeddings
 from chonkie.embeddings.jina import JinaEmbeddings
 from chonkie.embeddings.model2vec import Model2VecEmbeddings
 from chonkie.embeddings.openai import OpenAIEmbeddings
 from chonkie.embeddings.sentence_transformer import SentenceTransformerEmbeddings
-from chonkie.embeddings.voyageai import VoyageAIEmbeddings
 
 
 class TestAutoEmbeddingsModel2Vec:
@@ -95,9 +95,9 @@ class TestAutoEmbeddingsProviderPrefix:
 
     @pytest.mark.skipif(not os.getenv("VOYAGE_API_KEY"), reason="Voyage API key not set")
     def test_voyage_provider_prefix(self) -> None:
-        """Test VoyageAI embeddings with provider prefix."""
+        """Test VoyageAI embeddings with provider prefix (via CatsuEmbeddings)."""
         embeddings = AutoEmbeddings.get_embeddings("voyageai://voyage-3")
-        assert isinstance(embeddings, VoyageAIEmbeddings)
+        assert isinstance(embeddings, CatsuEmbeddings)
         assert embeddings.model == "voyage-3"
 
     @pytest.mark.skipif(not os.getenv("JINA_API_KEY"), reason="Jina API key not set")


### PR DESCRIPTION
This pull request updates the package version to 1.5.1 and modifies the test suite to reflect a change in how VoyageAI embeddings are handled. Specifically, it updates the tests to expect `CatsuEmbeddings` instead of `VoyageAIEmbeddings` for the "voyageai://" provider prefix, indicating an internal refactor or provider consolidation.

Version bump:

* Updated the package version from `1.5.0` to `1.5.1` in both `pyproject.toml` and `chonkie/__init__.py`. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L8-R8) [[2]](diffhunk://#diff-44a557df57b150a7b71a0b691e66e501f00f8983cc9c66dee9309aaf738bd408L101-R101)

Embeddings provider update in tests:

* Changed the import in `test_auto_embeddings.py` to use `CatsuEmbeddings` instead of `VoyageAIEmbeddings`, and updated the `test_voyage_provider_prefix` test to assert that `AutoEmbeddings.get_embeddings("voyageai://voyage-3")` returns a `CatsuEmbeddings` instance with the correct model. [[1]](diffhunk://#diff-7585626420dcc4a9a352acb5348e95afcdd10ef14cf9e0209d3a196f76eeb500R11-L16) [[2]](diffhunk://#diff-7585626420dcc4a9a352acb5348e95afcdd10ef14cf9e0209d3a196f76eeb500L98-R100)