### PR TITLE
fix: enable PyTorch MPS fallback on macOS to resolve NotImplementedError

### DIFF
--- a/src/chonkie/__init__.py
+++ b/src/chonkie/__init__.py
@@ -1,5 +1,13 @@
 """Main package for Chonkie."""
 
+import importlib.util
+import os
+import platform
+
+# Enable PyTorch fallback for MPS (Apple Silicon) to support operations like _embedding_bag
+if platform.system() == "Darwin" and importlib.util.find_spec("torch"):
+    os.environ.setdefault("PYTORCH_ENABLE_MPS_FALLBACK", "1")
+
 from .chef import BaseChef, MarkdownChef, TableChef, TextChef
 from .chunker import (
     BaseChunker,


### PR DESCRIPTION
## Summary
This PR addresses a compatibility issue encountered on macOS devices with Apple Silicon (M1/M2/M3) when using PyTorch with the Metal Performance Shaders (MPS) backend.

Specific operations used by some embedding models and tokenizers (specifically `aten::_embedding_bag`) are currently not implemented in the MPS backend, causing `NotImplementedError` crashes during tests and runtime execution.

This change enables the `PYTORCH_ENABLE_MPS_FALLBACK` environment variable automatically when running on Darwin (macOS) systems. This ensures that unsupported operations gracefully fall back to the CPU execution, preventing crashes while still leveraging MPS for supported operations.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Verification
- **Environment**: macOS (Apple Silicon)
- **Tests**: Ran verify tests that were previously failing.
  - `pytest tests/handshakes/test_qdrant_handshake.py`: **Failed** before changes, **Passed** after.
  - [pytest](cci:1://file:///Users/limemanas/Desktop/chonkie/tests/conftest.py:5:0-7:46): Full suite passed on macOS.

## Related Issues
- Fixing `NotImplementedError: The operator 'aten::_embedding_bag' is not currently implemented for the MPS device.`