### PR TITLE
docs: Add GroqGenie and CerebrasGenie documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,15 +243,17 @@ Seamlessly works with various embedding model providers. Bring your favorite emb
 </details>
 
 <details>
-<summary><strong>🧞‍♂️ Power Up with Genies! Chonkie supports 3+ LLM providers!</strong></summary>
+<summary><strong>🧞‍♂️ Power Up with Genies! Chonkie supports 5+ LLM providers!</strong></summary>
 
 Genies provide interfaces to interact with Large Language Models (LLMs) for advanced chunking strategies or other tasks within the pipeline.
 
-| Genie Name     | Class              | Description                       | Optional Install        |
-| -------------- | ------------------ | --------------------------------- | ----------------------- |
-| `gemini`       | `GeminiGenie`      | Interact with Google Gemini APIs. | `chonkie[gemini]`       |
-| `openai`       | `OpenAIGenie`      | Interact with OpenAI APIs.        | `chonkie[openai]`       |
-| `azure-openai` | `AzureOpenAIGenie` | Interact with Azure OpenAI APIs.  | `chonkie[azure-openai]` |
+| Genie Name     | Class              | Description                                | Optional Install        |
+| -------------- | ------------------ | ------------------------------------------ | ----------------------- |
+| `gemini`       | `GeminiGenie`      | Interact with Google Gemini APIs.          | `chonkie[gemini]`       |
+| `openai`       | `OpenAIGenie`      | Interact with OpenAI APIs.                 | `chonkie[openai]`       |
+| `azure-openai` | `AzureOpenAIGenie` | Interact with Azure OpenAI APIs.           | `chonkie[azure-openai]` |
+| `groq`         | `GroqGenie`        | Fast inference on Groq hardware.           | `chonkie[groq]`         |
+| `cerebras`     | `CerebrasGenie`    | Fastest inference on Cerebras hardware.    | `chonkie[cerebras]`     |
 
 You can also use the `OpenAIGenie` to interact with any LLM provider that supports the OpenAI API format, by simply changing the `model`, `base_url`, and `api_key` parameters. For example, here's how to use the `OpenAIGenie` to interact with the `Llama-4-Maverick` model via OpenRouter:
 

--- a/docs/oss/changelog.mdx
+++ b/docs/oss/changelog.mdx
@@ -6,6 +6,40 @@ icon: "hippo"
 iconType: "solid"
 ---
 
+<Update label="v1.5.4">
+  # v1.5.4 Release Highlights ✨
+
+  - **New `GroqGenie`**: Fast inference on Groq hardware! Use Llama models with blazing speed via Groq's infrastructure.
+
+  ```bash
+  pip install "chonkie[groq]"
+  ```
+
+  ```python
+  from chonkie import GroqGenie
+
+  genie = GroqGenie(model="llama-3.3-70b-versatile")
+  response = genie.generate("Hello!")
+  ```
+
+  - **New `CerebrasGenie`**: Fastest inference on Cerebras hardware! Experience ultra-fast LLM inference.
+
+  ```bash
+  pip install "chonkie[cerebras]"
+  ```
+
+  ```python
+  from chonkie import CerebrasGenie
+
+  genie = CerebrasGenie(model="llama-3.3-70b")
+  response = genie.generate("Hello!")
+  ```
+
+  Both new Genies support `generate()` for text generation and `generate_json()` for structured JSON output, following the same interface as existing Genies.
+
+  **Full Changelog**: https://github.com/chonkie-inc/chonkie/compare/v1.5.3...v1.5.4
+</Update>
+
 <Update label="v1.3.0">
   # v1.3.0 Release Highlights ✨
 

--- a/docs/oss/chunkers/slumber-chunker.mdx
+++ b/docs/oss/chunkers/slumber-chunker.mdx
@@ -13,7 +13,14 @@ To use the `SlumberChunker` via the API, check out the [API reference documentat
 
 ## Introducing Genie! 🧞
 
-The magic behind `SlumberChunker` is **Genie**, Chonkie's new interface for integrating generative models and APIs (like Gemini, OpenAI, Anthropic, etc.). Genie allows `SlumberChunker` to intelligently analyze text structure, identify optimal split points, and even summarize or rephrase content for the best possible chunk quality.
+The magic behind `SlumberChunker` is **Genie**, Chonkie's interface for integrating generative models and APIs. Genie allows `SlumberChunker` to intelligently analyze text structure, identify optimal split points, and even summarize or rephrase content for the best possible chunk quality.
+
+**Available Genies:**
+- `GeminiGenie` - Google Gemini APIs
+- `OpenAIGenie` - OpenAI APIs (also works with OpenAI-compatible providers)
+- `AzureOpenAIGenie` - Azure OpenAI APIs
+- `GroqGenie` - Fast inference on Groq hardware
+- `CerebrasGenie` - Fastest inference on Cerebras hardware
 
 <Card title="Requires [genie] Install" icon="wand-magic">
   To unleash the power of SlumberChunker and Genie, you need the `[genie]`

--- a/docs/oss/installation.mdx
+++ b/docs/oss/installation.mdx
@@ -132,6 +132,12 @@ pip install "chonkie[neural]"
 # For SlumberChunker support (Genie/LLM interface)
 pip install "chonkie[genie]"
 
+# For Groq Genie support (fast inference)
+pip install "chonkie[groq]"
+
+# For Cerebras Genie support (fastest inference)
+pip install "chonkie[cerebras]"
+
 # For installing multiple features together
 pip install "chonkie[st, code, genie]"
 
@@ -193,6 +199,8 @@ Here's what each installation option adds:
 | 'code'              | + tree-sitter, tree-sitter-language-pack, magika          |
 | 'neural'            | + transformers, torch (or tensorflow/flax), sentencepiece |
 | 'genie'             | + pydantic, google-genai                                  |
+| 'groq'              | + pydantic, groq                                          |
+| 'cerebras'          | + pydantic, cerebras-cloud-sdk                            |
 | 'all'               | all above dependencies                                    |
 
 _(Note: Specific dependencies for `[genie]` might vary slightly based on implementation details and chosen models/APIs.)_


### PR DESCRIPTION
## Summary

Documentation updates for the newly added `GroqGenie` and `CerebrasGenie`.

## Changes

- **README.md**: Updated genies table (now "5+ LLM providers"), added Groq and Cerebras entries
- **docs/oss/installation.mdx**: Added `chonkie[groq]` and `chonkie[cerebras]` install options and dependencies
- **docs/oss/chunkers/slumber-chunker.mdx**: Listed all available genies in the Genie introduction section
- **docs/oss/changelog.mdx**: Added v1.5.4 changelog entry documenting the new genies

## Related

Follows up on PR #453 which added the implementation.