### PR TITLE
refactor: replace memchunk with chonkie-core in FastChunker

### DIFF
--- a/docs/oss/chunkers/fast-chunker.mdx
+++ b/docs/oss/chunkers/fast-chunker.mdx
@@ -4,20 +4,12 @@ description: "SIMD-accelerated text chunking at 100+ GB/s throughput"
 icon: "bolt"
 ---
 
-The `FastChunker` uses [memchunk](https://github.com/chonkie-inc/memchunk) for SIMD-accelerated boundary detection, enabling chunking speeds of 100+ GB/s.
+The `FastChunker` uses [chonkie-core](https://github.com/chonkie-inc/chunk) for SIMD-accelerated boundary detection, enabling chunking speeds of 100+ GB/s.
 
 <Warning>
   Unlike other chunkers, FastChunker uses **byte size** limits instead of token counts.
   This tradeoff enables extreme performance for high-throughput pipelines.
 </Warning>
-
-## Installation
-
-FastChunker requires the `memchunk` library:
-
-```bash
-pip install chonkie[fast]
-```
 
 ## Initialization
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,6 @@ code = [
     "magika>=0.6.0, <1.1.0",
 ]
 neural = ["transformers>=4.0.0", "torch>=2.0.0, <3.0"]
-fast = ["memchunk>=0.3.0"]
 
 # Optional dependencies for the embeddings
 
@@ -156,7 +155,6 @@ all = [
     "catsu>=0.0.1",
     "litellm>=1.0.0",
     "datasets>=1.14.0",
-    "memchunk>=0.3.0",
 ]
 dev = [
     "datasets>=1.14.0",

--- a/src/chonkie/chunker/fast.py
+++ b/src/chonkie/chunker/fast.py
@@ -1,6 +1,8 @@
-"""Fast chunker powered by memchunk."""
+"""Fast chunker powered by chonkie-core."""
 
 from typing import Any, Dict, List, Optional, Sequence
+
+import chonkie_core
 
 from chonkie.chunker.base import BaseChunker
 from chonkie.pipeline import chunker
@@ -14,7 +16,7 @@ class FastChunker(BaseChunker):
     Unlike other chonkie chunkers that use token counts, FastChunker uses
     byte size limits for maximum performance (~100+ GB/s throughput).
 
-    This is a thin wrapper around memchunk's chunking functionality.
+    This is a thin wrapper around chonkie-core's chunking functionality.
 
     Args:
         chunk_size: Target chunk size in bytes (default: 4096)
@@ -53,16 +55,6 @@ class FastChunker(BaseChunker):
         self.prefix = prefix
         self.consecutive = consecutive
         self.forward_fallback = forward_fallback
-        # Lazy import memchunk.
-        try:
-            from memchunk import chunk_offsets
-        except ImportError as ie:
-            raise ImportError(
-                "memchunk is required for FastChunker. Install it with: pip install chonkie[fast]"
-            ) from ie
-
-        # Verify memchunk is available
-        self._chunk_offsets = chunk_offsets
 
     def __repr__(self) -> str:
         """Return a string representation of the chunker."""
@@ -85,7 +77,7 @@ class FastChunker(BaseChunker):
         if not text:
             return []
 
-        # Build kwargs for memchunk
+        # Build kwargs for chonkie-core
         kwargs: Dict[str, Any] = {
             "size": self.chunk_size,
             "prefix": self.prefix,
@@ -98,11 +90,11 @@ class FastChunker(BaseChunker):
         else:
             kwargs["delimiters"] = self.delimiters
 
-        # Encode to bytes for memchunk (which works with byte offsets)
+        # Encode to bytes for chonkie-core (which works with byte offsets)
         text_bytes = text.encode("utf-8")
 
-        # Get chunk offsets from memchunk (these are byte offsets)
-        offsets = self._chunk_offsets(text_bytes, **kwargs)
+        # Get chunk offsets from chonkie-core (these are byte offsets)
+        offsets = chonkie_core.chunk_offsets(text_bytes, **kwargs)
 
         # Convert to Chunk objects by slicing bytes and decoding
         # Track character position to convert byte offsets to char offsets


### PR DESCRIPTION
## Summary
- Replace `memchunk` dependency with `chonkie-core` in FastChunker
- Remove `chonkie[fast]` optional extra (no longer needed)
- FastChunker now works out of the box

## Changes
- **`fast.py`**: Use `chonkie_core.chunk_offsets` instead of `memchunk.chunk_offsets`
- **`pyproject.toml`**: Remove `fast` optional extra and `memchunk` from dev dependencies
- **`fast-chunker.mdx`**: Update docs to reference chonkie-core, remove installation section

## Why
Since `chonkie-core` is already a required dependency and provides the same `chunk_offsets` API as `memchunk`, there's no need for a separate optional dependency.

## Test plan
- [x] All 23 fast chunker tests pass
- [x] ruff and mypy checks pass