### PR TITLE
Format chunker modules with ruff

### DIFF
--- a/src/chonkie/chunker/recursive.py
+++ b/src/chonkie/chunker/recursive.py
@@ -167,8 +167,7 @@ class RecursiveChunker(BaseChunker):
             # Encode, Split, and Decode
             encoded = self.tokenizer.encode(text)
             token_splits = [
-                encoded[i : i + self.chunk_size]
-                for i in range(0, len(encoded), self.chunk_size)
+                encoded[i : i + self.chunk_size] for i in range(0, len(encoded), self.chunk_size)
             ]
             splits = list(self.tokenizer.decode_batch(token_splits))
             return splits

--- a/src/chonkie/chunker/semantic.py
+++ b/src/chonkie/chunker/semantic.py
@@ -21,7 +21,6 @@ from .base import BaseChunker
 logger = get_logger(__name__)
 
 
-
 @chunker("semantic")
 class SemanticChunker(BaseChunker):
     """SemanticChunker uses peak detection to find split points and direct window embedding calculation.

--- a/src/chonkie/chunker/slumber.py
+++ b/src/chonkie/chunker/slumber.py
@@ -353,8 +353,7 @@ class SlumberChunker(BaseChunker):
             # Token-based splitting
             encoded = self.tokenizer.encode(text)
             token_splits = [
-                encoded[i : i + self.chunk_size]
-                for i in range(0, len(encoded), self.chunk_size)
+                encoded[i : i + self.chunk_size] for i in range(0, len(encoded), self.chunk_size)
             ]
             return list(self.tokenizer.decode_batch(token_splits))
 


### PR DESCRIPTION
Applied ruff formatting to the chunker modules so they match the current CI formatting rules.
No functional changes formatting only.