### PR TITLE
fix: make BaseChunker multiprocessing safe by default

### DIFF
--- a/src/chonkie/chunker/base.py
+++ b/src/chonkie/chunker/base.py
@@ -26,7 +26,7 @@ class BaseChunker(ABC):
 
         """
         self._tokenizer = AutoTokenizer(tokenizer)
-        self._use_multiprocessing = True
+        self._use_multiprocessing = False
         logger.debug(
             f"Initialized {self.__class__.__name__}",
             tokenizer=str(tokenizer)[:50],


### PR DESCRIPTION

## Description

### Problem
The `BaseChunker` class was defaulting `_use_multiprocessing = True`, which caused issues for users creating custom chunkers. When `chunk_batch()` was called on multiple texts, it would attempt parallel processing using `multiprocessing.Pool`, but most custom chunker implementations are not pickleable, leading to `AttributeError` or pickle-related errors.

### Root Cause
- Base class sets `_use_multiprocessing = True` by default
- All existing concrete chunkers override this to `False` in their `__init__` methods
- Custom chunkers inheriting from `BaseChunker` would inherit the unsafe default
- Multiprocessing requires the entire chunker instance (including the `chunk` method) to be pickleable

### Solution
Changed the default value in `BaseChunker.__init__()` from:
```python
self._use_multiprocessing = True
```
to:
```python
self._use_multiprocessing = False
```

### Benefits
- **Safe by default**: Custom chunkers work out-of-the-box without pickle errors
- **Backward compatible**: All existing chunkers already set this to `False`
- **Opt-in performance**: Users can still enable multiprocessing by setting `_use_multiprocessing = True` if their implementation is pickleable
- **Better developer experience**: Prevents confusing errors for new users

### Files Changed
- `src/chonkie/chunker/base.py`: Changed multiprocessing default in `BaseChunker.__init__()`

### Testing
- No breaking changes to existing functionality
- Custom chunkers will now work safely without modification
- Existing chunkers continue to work as before