### PR TITLE
Improve error handling for neural model and tokenizer loading

### DIFF
--- a/src/chonkie/chunker/neural.py
+++ b/src/chonkie/chunker/neural.py
@@ -88,8 +88,16 @@ class NeuralChunker(BaseChunker):
                 raise ValueError(
                     "Invalid tokenizer provided. Please provide a string or a transformers.PreTrainedTokenizerFast object.",
                 )
-        except Exception as e:
-            raise ValueError(f"Error initializing tokenizer: {e}") from e
+        except OSError as e:
+            raise ValueError(
+                f"Failed to load tokenizer '{tokenizer}'. "
+                "Check that the tokenizer name is correct."
+            ) from e
+        except ValueError as e:
+            raise ValueError(
+                "The provided tokenizer is invalid or incompatible with the model."
+            ) from e
+
 
         # Initialize the Parent class with the tokenizer
         super().__init__(cast(TokenizerProtocol, tokenizer))
@@ -117,8 +125,15 @@ class NeuralChunker(BaseChunker):
                 raise ValueError(
                     "Invalid model provided. Please provide a string or a transformers.AutoModelForTokenClassification object.",
                 )
-        except Exception as e:
-            raise ValueError(f"Error initializing model: {e}") from e
+        except OSError as e:
+            raise ValueError(
+                f"Failed to load model '{model}'. "
+                "Check that the model name is correct."
+            ) from e
+        except ValueError as e:
+            raise ValueError(
+                "The model is not compatible with token-classification."
+            ) from e
 
         # Set the attributes
         self.min_characters_per_chunk = min_characters_per_chunk

--- a/src/chonkie/chunker/neural.py
+++ b/src/chonkie/chunker/neural.py
@@ -76,7 +76,7 @@ class NeuralChunker(BaseChunker):
             raise ImportError(
                 "transformers is not installed. Please install it with `pip install chonkie[neural]`.",
             ) from e
-        
+
         # Initialize the model and stride
         if isinstance(model, str):
             # Check if the model is supported

--- a/src/chonkie/chunker/neural.py
+++ b/src/chonkie/chunker/neural.py
@@ -76,11 +76,33 @@ class NeuralChunker(BaseChunker):
             raise ImportError(
                 "transformers is not installed. Please install it with `pip install chonkie[neural]`.",
             ) from e
+        
+        # Initialize the model and stride
+        if isinstance(model, str):
+            # Check if the model is supported
+            if model not in self.SUPPORTED_MODELS:
+                raise ValueError(
+                    f"Model {model} is not supported. Please choose from one of the following: {self.SUPPORTED_MODELS}"
+                )
+            model_id = model
+            if stride is None:
+                stride = self.SUPPORTED_MODEL_STRIDES[model]
+        elif model is not None and "transformers" in str(type(model)):
+            # Assuming that the model is a transformers model already, since it has transformers in the name, teehee~
+            self.model = model
+            model_id = None
+            # Since a custom model is provided, we need to set the stride to 0
+            stride = 0 if stride is None else stride
+        else:
+            raise ValueError(
+                "Invalid model provided. Please provide a string or a transformers.AutoModelForTokenClassification object."
+            )
+
         # Initialize the tokenizer to pass in to the parent class
         if isinstance(tokenizer, str):
             tokenizer_id = tokenizer
-        elif tokenizer is None and isinstance(model, str):
-            tokenizer_id = model
+        elif tokenizer is None and model_id is not None:
+            tokenizer_id = model_id
         elif isinstance(tokenizer, PreTrainedTokenizerFast):
             tokenizer_id = None  # already loaded
         else:
@@ -100,32 +122,15 @@ class NeuralChunker(BaseChunker):
         # Initialize the Parent class with the tokenizer
         super().__init__(cast(TokenizerProtocol, tokenizer))
 
-        # Initialize the model and stride
-        if isinstance(model, str):
-            # Check if the model is supported
-            if model not in self.SUPPORTED_MODELS:
-                raise ValueError(
-                    f"Model {model} is not supported. Please choose from one of the following: {self.SUPPORTED_MODELS}"
-                )
-            model_id = model
-        elif model is not None and "transformers" in str(type(model)):
-            # Assuming that the model is a transformers model already, since it has transformers in the name, teehee~
-            self.model = model
-            model_id = None
-            # Since a custom model is provided, we need to set the stride to 0
-            stride = 0 if stride is None else stride
-        else:
-            raise ValueError(
-                "Invalid model provided. Please provide a string or a transformers.AutoModelForTokenClassification object."
-            )
-
         if model_id is not None:
             try:
                 self.model = AutoModelForTokenClassification.from_pretrained(
                     model_id, device_map=device_map
                 )
             except OSError as e:
-                raise ValueError("The model is not compatible with token-classification.") from e
+                raise ValueError(
+                    f"Failed to load model '{model_id}' for token-classification: {e}"
+                ) from e
         # Set the attributes
         self.min_characters_per_chunk = min_characters_per_chunk
 
@@ -133,7 +138,7 @@ class NeuralChunker(BaseChunker):
         try:
             self.pipe = pipeline(
                 "token-classification",
-                model=model,
+                model=self.model,
                 tokenizer=tokenizer,
                 device_map=device_map,
                 aggregation_strategy="simple",

--- a/src/chonkie/chunker/neural.py
+++ b/src/chonkie/chunker/neural.py
@@ -77,64 +77,57 @@ class NeuralChunker(BaseChunker):
                 "transformers is not installed. Please install it with `pip install chonkie[neural]`.",
             ) from e
         # Initialize the tokenizer to pass in to the parent class
-        try:
-            if isinstance(tokenizer, str):
-                tokenizer = AutoTokenizer.from_pretrained(tokenizer)
-            elif tokenizer is None and isinstance(model, str):
-                tokenizer = AutoTokenizer.from_pretrained(model)
-            elif isinstance(tokenizer, PreTrainedTokenizerFast):
-                tokenizer = tokenizer
-            else:
+        if isinstance(tokenizer, str):
+            tokenizer_id = tokenizer
+        elif tokenizer is None and isinstance(model, str):
+            tokenizer_id = model
+        elif isinstance(tokenizer, PreTrainedTokenizerFast):
+            tokenizer_id = None  # already loaded
+        else:
+            raise ValueError(
+                "Invalid tokenizer provided. Please provide a string or a transformers.PreTrainedTokenizerFast object."
+            )
+        
+        if tokenizer_id is not None:
+            try:
+                tokenizer = AutoTokenizer.from_pretrained(tokenizer_id)
+            except OSError as e:
                 raise ValueError(
-                    "Invalid tokenizer provided. Please provide a string or a transformers.PreTrainedTokenizerFast object.",
-                )
-        except OSError as e:
-            raise ValueError(
-                f"Failed to load tokenizer '{tokenizer}'. "
-                "Check that the tokenizer name is correct."
-            ) from e
-        except ValueError as e:
-            raise ValueError(
-                "The provided tokenizer is invalid or incompatible with the model."
-            ) from e
-
+                    f"Failed to load tokenizer '{tokenizer_id}'. "
+                    "Check that the tokenizer name is correct."
+                ) from e    
 
         # Initialize the Parent class with the tokenizer
         super().__init__(cast(TokenizerProtocol, tokenizer))
 
         # Initialize the model and stride
-        try:
-            if isinstance(model, str):
-                # Check if the model is supported
-                if model not in self.SUPPORTED_MODELS:
-                    raise ValueError(
-                        f"Model {model} is not supported. Please choose from one of the following: {self.SUPPORTED_MODELS}",
-                    )
-                # Initialize the model
-                self.model = AutoModelForTokenClassification.from_pretrained(
-                    model, device_map=device_map
-                )
-                # Set the stride
-                stride = self.SUPPORTED_MODEL_STRIDES[model] if stride is None else stride
-            elif model is not None and "transformers" in str(type(model)):
-                # Assuming that the model is a transformers model already, since it has transformers in the name, teehee~
-                self.model = model
-                # Since a custom model is provided, we need to set the stride to 0
-                stride = 0 if stride is None else stride
-            else:
+        if isinstance(model, str):
+            # Check if the model is supported
+            if model not in self.SUPPORTED_MODELS:
                 raise ValueError(
-                    "Invalid model provided. Please provide a string or a transformers.AutoModelForTokenClassification object.",
+                    f"Model {model} is not supported. Please choose from one of the following: {self.SUPPORTED_MODELS}"
                 )
-        except OSError as e:
+            model_id = model
+        elif model is not None and "transformers" in str(type(model)):
+            # Assuming that the model is a transformers model already, since it has transformers in the name, teehee~
+            self.model = model
+            model_id = None
+            # Since a custom model is provided, we need to set the stride to 0
+            stride = 0 if stride is None else stride
+        else:
             raise ValueError(
-                f"Failed to load model '{model}'. "
-                "Check that the model name is correct."
-            ) from e
-        except ValueError as e:
-            raise ValueError(
-                "The model is not compatible with token-classification."
-            ) from e
-
+                "Invalid model provided. Please provide a string or a transformers.AutoModelForTokenClassification object."
+            )
+        
+        if model_id is not None:
+            try:
+                self.model = AutoModelForTokenClassification.from_pretrained(
+                    model_id, device_map=device_map
+                )
+            except OSError as e:
+                raise ValueError(
+                    "The model is not compatible with token-classification."
+                ) from e
         # Set the attributes
         self.min_characters_per_chunk = min_characters_per_chunk
 

--- a/src/chonkie/chunker/neural.py
+++ b/src/chonkie/chunker/neural.py
@@ -87,7 +87,7 @@ class NeuralChunker(BaseChunker):
             raise ValueError(
                 "Invalid tokenizer provided. Please provide a string or a transformers.PreTrainedTokenizerFast object."
             )
-        
+
         if tokenizer_id is not None:
             try:
                 tokenizer = AutoTokenizer.from_pretrained(tokenizer_id)
@@ -95,7 +95,7 @@ class NeuralChunker(BaseChunker):
                 raise ValueError(
                     f"Failed to load tokenizer '{tokenizer_id}'. "
                     "Check that the tokenizer name is correct."
-                ) from e    
+                ) from e
 
         # Initialize the Parent class with the tokenizer
         super().__init__(cast(TokenizerProtocol, tokenizer))
@@ -118,16 +118,14 @@ class NeuralChunker(BaseChunker):
             raise ValueError(
                 "Invalid model provided. Please provide a string or a transformers.AutoModelForTokenClassification object."
             )
-        
+
         if model_id is not None:
             try:
                 self.model = AutoModelForTokenClassification.from_pretrained(
                     model_id, device_map=device_map
                 )
             except OSError as e:
-                raise ValueError(
-                    "The model is not compatible with token-classification."
-                ) from e
+                raise ValueError("The model is not compatible with token-classification.") from e
         # Set the attributes
         self.min_characters_per_chunk = min_characters_per_chunk
 


### PR DESCRIPTION
This PR makes error messages around model and tokenizer loading a bit clearer in NeuralChunker.

Instead of catching everything with a generic exception, it now raises more specific and helpful errors when:

a model or tokenizer can’t be loaded

an invalid or incompatible model/tokenizer is passed in

No behavior changes this just makes failures easier to understand and debug.