### PR TITLE
chore: bump version to 1.5.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "chonkie"
-version = "1.5.4"
+version = "1.5.5"
 description = "🦛 CHONK your texts with Chonkie ✨ - The no-nonsense chunking library"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/chonkie/__init__.py
+++ b/src/chonkie/__init__.py
@@ -161,6 +161,6 @@ __all__ = (
 )
 
 # This hippo grows with every release 🦛✨~
-__version__ = "1.5.3"
+__version__ = "1.5.5"
 __name__ = "chonkie"
 __author__ = "🦛 Chonkie Inc"


### PR DESCRIPTION
## Summary

Bump version to 1.5.5 for the next release.

## Changes in this release

- **#481**: fix: openai lazy import - Users without `openai` installed can now import chonkie without errors
- **#471**: fix: make BaseChunker multiprocessing safe by default - Custom chunkers now work out-of-the-box
- **#473**: fix: leaf node handling in CodeChunker - Prevents missing chunks in edge cases
- **#482**: chore: cleanup CodeChunker leaf node handling - Code quality improvements

## Files changed

- `pyproject.toml`: 1.5.4 → 1.5.5
- `src/chonkie/__init__.py`: 1.5.3 → 1.5.5 (also fixes version mismatch)