### PR TITLE
Remove completed TODO comments from NeuralChunker

### DIFF
--- a/src/chonkie/chunker/neural.py
+++ b/src/chonkie/chunker/neural.py
@@ -16,17 +16,6 @@ from .base import BaseChunker
 
 logger = get_logger(__name__)
 
-# TODO: Add a check to see if the model is supported
-
-# TODO: Add try/except block to catch if the model is not loaded correctly
-
-# TODO: Add a list of supported models to choose from
-
-# TODO: Allow for loading a custom model by passing in the model + tokenizer directly
-
-# TODO: Add stride parameters for the pipeline (also does the pipeline do it sequentially or in parallel?)
-# If they do it sequentially, then we are making a huge mistake by not batching and processing multiple texts at once.
-
 
 @chunker("neural")
 class NeuralChunker(BaseChunker):


### PR DESCRIPTION
# Remove Outdated TODO Comments from NeuralChunker

## Description
This PR removes outdated TODO comments from the `NeuralChunker` class in `src/chonkie/chunker/neural.py`. The TODO items were referencing features that have already been implemented in the codebase.

## Changes Made
- Removed 5 TODO comments from the top of `neural.py`:
  - Model support validation (already implemented via `SUPPORTED_MODELS` list and checks)
  - Try/except blocks for model loading (already implemented in `__init__`)
  - Supported models list (already implemented as class attribute)
  - Custom model loading support (already implemented via flexible `model` parameter)
  - Stride parameters for pipeline (already implemented as `stride` parameter)

## Impact
- **Code Quality**: Cleaner codebase without stale comments
- **No Functional Changes**: All referenced features are already working
- **Maintenance**: Reduces confusion for future developers

## Testing
- No tests needed as this is comment removal only
- Existing neural chunker tests should continue to pass

## Related Issues
N/A - Code cleanup task