### PR TITLE
Improve error handling 

### DIFF
--- a/src/chonkie/chunker/code.py
+++ b/src/chonkie/chunker/code.py
@@ -348,7 +348,8 @@ class CodeChunker(BaseChunker):
             logger.debug(f"Using configured language: {self.language}")
 
         try:
-            assert self.parser is not None, "Parser is not initialized."
+            if self.parser is None:
+                raise RuntimeError("Parser failed to initialize. Language detection or initialization failed.")
             # Create the parsing tree for the current code
             tree: Tree = self.parser.parse(original_text_bytes)
             root_node: Node = tree.root_node


### PR DESCRIPTION
# PR: Improve Error Handling in CodeChunker

## Summary
This pull request improves error handling in the `CodeChunker` class by replacing an `assert` statement with a proper `RuntimeError` exception. This change ensures that library users receive clear, actionable error messages when the parser fails to initialize, rather than an ambiguous `AssertionError`.

## Details
- **File:** `src/chonkie/chunker/code.py`
- **Change:**
  - Replaced:
    ```python
    assert self.parser is not None, "Parser is not initialized."
    ```
    with:
    ```python
    if self.parser is None:
        raise RuntimeError("Parser failed to initialize. Language detection or initialization failed.")
    ```
- **Reason:**
  - Assertions are intended for internal logic errors and can be disabled with Python's `-O` flag.
  - Raising a specific exception provides clearer feedback to developers using the library and allows for better error handling downstream.

## Impact
- Improves developer experience for all users of the `CodeChunker` class.
- No breaking changes to the public API.