### PR TITLE
fix: replace bare except with except Exception in Chunk.__str__

### DIFF
--- a/src/chonkie/types/base.py
+++ b/src/chonkie/types/base.py
@@ -76,7 +76,7 @@ class Chunk:
                 return preview
             else:
                 return str(self.embedding)
-        except:
+        except Exception:
             return "<embedding>"
 
     def __repr__(self) -> str:


### PR DESCRIPTION
Replace bare `except:` with `except Exception:` in `Chunk.__str__()`.