### PR TITLE
docs: fix semantic chunker embedding examples

### DIFF
--- a/docs/oss/embeddings/auto-embeddings.mdx
+++ b/docs/oss/embeddings/auto-embeddings.mdx
@@ -34,7 +34,7 @@ After loading the embeddings handler, you can use it in the same way you would u
 
 ```python
 from chonkie import SemanticChunker
-chunker = SemanticChunker(embeddings=embeddings, similarity_threshold=0.7)
+chunker = SemanticChunker(embedding_model=embeddings, threshold=0.7)
 
 # Chunk the text
 chunks = chunker(text)

--- a/docs/oss/embeddings/custom-embeddings.mdx
+++ b/docs/oss/embeddings/custom-embeddings.mdx
@@ -70,6 +70,6 @@ embeddings = AutoEmbeddings.get_embeddings("custom/my-custom-embeddings")
 Finally, we can use our custom embeddings handler in the same way we would use any other embeddings handler.
 
 ```python
-chunker = SemanticChunker(embeddings=embeddings, similarity_threshold=0.7)
+chunker = SemanticChunker(embedding_model=embeddings, threshold=0.7)
 chunks = chunker(text)
 ```


### PR DESCRIPTION
This PR fixes incorrect `SemanticChunker` examples in the embeddings documentation.

The examples previously used `embeddings=...` and `similarity_threshold=...`, but the correct argument name is `embedding_model=...` and `threshold=...`.

```
@chunker("semantic")
class SemanticChunker(BaseChunker):

    def __init__(
        self,
        embedding_model: Union[str, BaseEmbeddings] = "minishlab/potion-base-32M",
        threshold: float = 0.8,
```
