### PR TITLE
feat: add filename to metadata

### DIFF
--- a/src/chonkie/chef/base.py
+++ b/src/chonkie/chef/base.py
@@ -3,6 +3,7 @@
 import asyncio
 import os
 from abc import ABC, abstractmethod
+from pathlib import Path
 
 from chonkie.logger import get_logger
 from chonkie.types import Document
@@ -12,6 +13,11 @@ logger = get_logger(__name__)
 
 class BaseChef(ABC):
     """Base class for chefs."""
+
+    @staticmethod
+    def _set_source_filename(doc: Document, path: str | os.PathLike) -> None:
+        """Set the filename key in doc.metadata to the basename of `path`."""
+        doc.metadata["filename"] = Path(path).name
 
     @abstractmethod
     def process(self, path: str | os.PathLike) -> Document:

--- a/src/chonkie/chef/markdown.py
+++ b/src/chonkie/chef/markdown.py
@@ -245,4 +245,6 @@ class MarkdownChef(BaseChef):
         markdown = self.read(path)
 
         # Use parse to process the content
-        return self.parse(markdown)
+        doc = self.parse(markdown)
+        self._set_source_filename(doc, path)
+        return doc

--- a/src/chonkie/chef/table.py
+++ b/src/chonkie/chef/table.py
@@ -67,7 +67,9 @@ class TableChef(BaseChef):
                 logger.info(f"CSV processing complete: converted {len(df)} rows to markdown")
                 # CSV always produces a single table
                 table = MarkdownTable(content=markdown, start_index=0, end_index=len(markdown))
-                return MarkdownDocument(content=markdown, tables=[table])
+                doc = MarkdownDocument(content=markdown, tables=[table])
+                self._set_source_filename(doc, path)
+                return doc
             elif str_path.endswith(".xls") or str_path.endswith(".xlsx"):
                 logger.debug("Processing Excel file")
                 all_df = pd.read_excel(str_path, sheet_name=None)
@@ -82,7 +84,9 @@ class TableChef(BaseChef):
                 logger.info(
                     f"Excel processing complete: converted {len(all_df)} sheets to markdown",
                 )
-                return MarkdownDocument(content=content, tables=tables)
+                doc = MarkdownDocument(content=content, tables=tables)
+                self._set_source_filename(doc, path)
+                return doc
         # Not a file, treat as markdown string and extract tables
         logger.debug("Extracting tables from markdown string")
         return self.parse(str(path))

--- a/src/chonkie/chef/text.py
+++ b/src/chonkie/chef/text.py
@@ -30,7 +30,9 @@ class TextChef(BaseChef):
         logger.debug(f"Processing text file: {path}")
         content = self.read(path)
         logger.info(f"Text processing complete: read {len(content)} characters from {path}")
-        return Document(content=content)
+        doc = Document(content=content)
+        self._set_source_filename(doc, path)
+        return doc
 
     def parse(self, text: str) -> Document:
         """Parse raw text into a Document.

--- a/src/chonkie/chunker/base.py
+++ b/src/chonkie/chunker/base.py
@@ -283,8 +283,20 @@ class BaseChunker(ABC):
             for c in new_chunks
         ]
 
+    @staticmethod
+    def _propagate_document_metadata(document: Document) -> None:
+        """Merge ``document.metadata`` into each chunk (existing chunk keys take precedence)."""
+        if not document.metadata or not document.chunks:
+            return
+        doc_meta = document.metadata
+        for chunk in document.chunks:
+            chunk.metadata = {**doc_meta, **chunk.metadata}
+
     def chunk_document(self, document: Document) -> Document:
         """Chunk a document.
+
+        After chunking, non-empty ``document.metadata`` is shallow-merged into each
+        chunk's :attr:`~chonkie.types.Chunk.metadata` (chunk keys override on conflict).
 
         Args:
             document: The document to chunk.
@@ -299,6 +311,7 @@ class BaseChunker(ABC):
             document.chunks = self._merge_new_chunks(document.chunks, chunk_results)
         else:
             document.chunks = self.chunk(document.content)
+        self._propagate_document_metadata(document)
         return document
 
     async def achunk_document(self, document: Document) -> Document:
@@ -318,4 +331,5 @@ class BaseChunker(ABC):
             document.chunks = self._merge_new_chunks(document.chunks, chunk_results)
         else:
             document.chunks = await self.achunk(document.content)
+        self._propagate_document_metadata(document)
         return document

--- a/src/chonkie/chunker/table.py
+++ b/src/chonkie/chunker/table.py
@@ -255,6 +255,7 @@ class TableChunker(BaseChunker):
             document.chunks = self.chunk(document.content)
             document.chunks.sort(key=lambda x: x.start_index)
         logger.info(f"Document chunking complete: {len(document.chunks)} chunks created")
+        BaseChunker._propagate_document_metadata(document)
         return document
 
     def __repr__(self) -> str:

--- a/src/chonkie/handshakes/base.py
+++ b/src/chonkie/handshakes/base.py
@@ -1,6 +1,7 @@
 """Base class for Handshakes."""
 
 import asyncio
+import json
 import uuid
 from abc import ABC, abstractmethod
 from typing import (
@@ -16,7 +17,31 @@ logger = get_logger(__name__)
 
 
 class BaseHandshake(ABC):
-    """Abstract base class for Handshakes."""
+    """Abstract base class for Handshakes.
+
+    Implementations merge :attr:`~chonkie.types.Chunk.metadata` into stored records
+    where supported; handshake fields (``text``, indices, etc.) override user keys.
+    """
+
+    @staticmethod
+    def _merge_chunk_metadata(chunk: Chunk, fields: dict[str, Any]) -> dict[str, Any]:
+        """Merge ``chunk.metadata`` under ``fields`` (``fields`` wins on key conflicts)."""
+        raw = getattr(chunk, "metadata", None)
+        extra: dict[str, Any] = raw if isinstance(raw, dict) else {}
+        return {**extra, **fields}
+
+    @staticmethod
+    def _coerce_flat_metadata(merged: dict[str, Any]) -> dict[str, Union[str, int, float, bool]]:
+        """Coerce values for stores that only accept primitives (e.g. Chroma, Pinecone metadata)."""
+        out: dict[str, Union[str, int, float, bool]] = {}
+        for key, val in merged.items():
+            if isinstance(val, (str, int, float, bool)):
+                out[key] = val
+            elif val is None:
+                continue
+            else:
+                out[key] = json.dumps(val, default=str)
+        return out
 
     @staticmethod
     def _generate_id(text: str) -> str:

--- a/src/chonkie/handshakes/chroma.py
+++ b/src/chonkie/handshakes/chroma.py
@@ -84,8 +84,6 @@ class ChromaEmbeddingFunction:
 class ChromaHandshake(BaseHandshake):
     """Chroma Handshake to export Chonkie's Chunks into a Chroma collection.
 
-    This handshake is experimental and may change in the future. Not all Chonkie features are supported yet.
-
     Args:
         client: The Chroma client to use.
         collection_name: The name of the collection to use.
@@ -163,11 +161,15 @@ class ChromaHandshake(BaseHandshake):
 
     def _generate_metadata(self, chunk: Chunk) -> dict[str, str | int | float | bool]:
         """Generate the metadata for the Chunk."""
-        return {
-            "start_index": chunk.start_index,
-            "end_index": chunk.end_index,
-            "token_count": chunk.token_count,
-        }
+        merged = self._merge_chunk_metadata(
+            chunk,
+            {
+                "start_index": chunk.start_index,
+                "end_index": chunk.end_index,
+                "token_count": chunk.token_count,
+            },
+        )
+        return self._coerce_flat_metadata(merged)
 
     def write(self, chunks: Union[Chunk, list[Chunk]]) -> None:
         """Write the Chunks to the Chroma collection."""

--- a/src/chonkie/handshakes/elastic.py
+++ b/src/chonkie/handshakes/elastic.py
@@ -113,13 +113,16 @@ class ElasticHandshake(BaseHandshake):
             actions.append({
                 "_index": self.index_name,
                 "_id": self._generate_id(f"{self.index_name}::chunk-{i}:{chunk.text}"),
-                "_source": {
-                    "text": chunk.text,
-                    "embedding": embeddings[i],
-                    "start_index": chunk.start_index,
-                    "end_index": chunk.end_index,
-                    "token_count": chunk.token_count,
-                },
+                "_source": self._merge_chunk_metadata(
+                    chunk,
+                    {
+                        "text": chunk.text,
+                        "embedding": embeddings[i],
+                        "start_index": chunk.start_index,
+                        "end_index": chunk.end_index,
+                        "token_count": chunk.token_count,
+                    },
+                ),
             })
         return actions
 
@@ -182,12 +185,13 @@ class ElasticHandshake(BaseHandshake):
         matches = []
         for hit in results["hits"]["hits"]:
             source = hit["_source"]
-            matches.append({
+            row: dict[str, Any] = {
                 "id": hit["_id"],
                 "score": hit["_score"],
-                "text": source.get("text"),
-                "start_index": source.get("start_index"),
-                "end_index": source.get("end_index"),
-                "token_count": source.get("token_count"),
-            })
+            }
+            for key, val in source.items():
+                if key == "embedding":
+                    continue
+                row[key] = val
+            matches.append(row)
         return matches

--- a/src/chonkie/handshakes/lancedb.py
+++ b/src/chonkie/handshakes/lancedb.py
@@ -1,6 +1,7 @@
 """LanceDB Handshake to export Chonkie's Chunks into a LanceDB table."""
 
 import importlib.util as importutil
+import json
 import os
 from typing import (
     TYPE_CHECKING,
@@ -102,6 +103,11 @@ class LanceDBHandshake(BaseHandshake):
                 pa.field("start_index", pa.int32()),
                 pa.field("end_index", pa.int32()),
                 pa.field("token_count", pa.int32()),
+                pa.field(
+                    "chunk_metadata",
+                    pa.utf8(),
+                    metadata={"description": "JSON-serialized Chunk.metadata"},
+                ),
                 pa.field("vector", pa.list_(pa.float32(), self.dimension)),
             ])
             self.table = self.connection.create_table(self.table_name, schema=schema)
@@ -115,12 +121,14 @@ class LanceDBHandshake(BaseHandshake):
 
     def _generate_row(self, chunk: Chunk, embedding: list[float]) -> dict:
         """Generate a row dict for the chunk."""
+        meta_str = json.dumps(chunk.metadata, sort_keys=True) if chunk.metadata else ""
         return {
             "id": self._generate_id(f"{self.table_name}:{chunk.start_index}:{chunk.text}"),
             "text": chunk.text,
             "start_index": chunk.start_index,
             "end_index": chunk.end_index,
             "token_count": chunk.token_count,
+            "chunk_metadata": meta_str,
             "vector": embedding,
         }
 
@@ -183,8 +191,9 @@ class LanceDBHandshake(BaseHandshake):
         query_builder: Any = self.table.search(embedding)
         results = query_builder.metric("cosine").limit(limit).to_list()  # ty: ignore[unresolved-attribute]
 
-        matches = [
-            {
+        matches: list[dict[str, Any]] = []
+        for r in results:
+            row: dict[str, Any] = {
                 "id": r["id"],
                 "score": 1.0 - r["_distance"],  # cosine distance -> similarity
                 "text": r["text"],
@@ -192,7 +201,14 @@ class LanceDBHandshake(BaseHandshake):
                 "end_index": r["end_index"],
                 "token_count": r["token_count"],
             }
-            for r in results
-        ]
+            raw_meta = r.get("chunk_metadata")
+            if raw_meta:
+                try:
+                    parsed = json.loads(raw_meta)
+                    if isinstance(parsed, dict):
+                        row = {**parsed, **row}
+                except json.JSONDecodeError:
+                    pass
+            matches.append(row)
         logger.info(f"Search complete: found {len(matches)} matching chunks")
         return matches

--- a/src/chonkie/handshakes/lancedb.py
+++ b/src/chonkie/handshakes/lancedb.py
@@ -121,7 +121,9 @@ class LanceDBHandshake(BaseHandshake):
 
     def _generate_row(self, chunk: Chunk, embedding: list[float]) -> dict:
         """Generate a row dict for the chunk."""
-        meta_str = json.dumps(chunk.metadata, sort_keys=True) if chunk.metadata else ""
+        meta_str = (
+            json.dumps(chunk.metadata, sort_keys=True, default=str) if chunk.metadata else ""
+        )
         return {
             "id": self._generate_id(f"{self.table_name}:{chunk.start_index}:{chunk.text}"),
             "text": chunk.text,

--- a/src/chonkie/handshakes/milvus.py
+++ b/src/chonkie/handshakes/milvus.py
@@ -1,6 +1,7 @@
 """Milvus Handshake to export Chonkie's Chunks into a Milvus collection."""
 
 import importlib.util as importutil
+import json
 from typing import (
     Any,
     Literal,
@@ -149,6 +150,7 @@ class MilvusHandshake(BaseHandshake):
             FieldSchema(name="start_index", dtype=DataType.INT64),
             FieldSchema(name="end_index", dtype=DataType.INT64),
             FieldSchema(name="token_count", dtype=DataType.INT64),
+            FieldSchema(name="chunk_metadata", dtype=DataType.VARCHAR, max_length=65_535),
             FieldSchema(name="embedding", dtype=DataType.FLOAT_VECTOR, dim=self.dimension),
         ]
         schema = CollectionSchema(fields, description="Chonkie Handshake Collection")
@@ -174,9 +176,20 @@ class MilvusHandshake(BaseHandshake):
         start_indices = [chunk.start_index for chunk in chunks]
         end_indices = [chunk.end_index for chunk in chunks]
         token_counts = [chunk.token_count for chunk in chunks]
+        chunk_metadata = [
+            json.dumps(chunk.metadata, sort_keys=True) if chunk.metadata else ""
+            for chunk in chunks
+        ]
         embeddings = self.embedding_model.embed_batch(texts)
 
-        data_to_insert = [texts, start_indices, end_indices, token_counts, embeddings]
+        data_to_insert = [
+            texts,
+            start_indices,
+            end_indices,
+            token_counts,
+            chunk_metadata,
+            embeddings,
+        ]
 
         mutation_result = self.collection.insert(data_to_insert)
         self.collection.flush()  # Essential to make data searchable
@@ -223,7 +236,7 @@ class MilvusHandshake(BaseHandshake):
 
         # Default search parameters for HNSW index
         search_params = {"metric_type": "L2", "params": {"ef": 64}}
-        output_fields = ["text", "start_index", "end_index", "token_count"]
+        output_fields = ["text", "start_index", "end_index", "token_count", "chunk_metadata"]
 
         results = self.collection.search(
             data=query_vectors,
@@ -237,10 +250,19 @@ class MilvusHandshake(BaseHandshake):
         matches = []
         # Results are for the first query vector (index 0)
         for hit in results[0]:
-            match_data = {
+            entity = dict(hit.entity) if hit.entity else {}
+            raw_meta = entity.pop("chunk_metadata", None)
+            match_data: dict[str, Any] = {
                 "id": hit.id,
                 "score": hit.distance,  # Milvus uses 'distance', which is analogous to score
-                **hit.entity,
+                **entity,
             }
+            if raw_meta:
+                try:
+                    parsed = json.loads(raw_meta)
+                    if isinstance(parsed, dict):
+                        match_data = {**parsed, **match_data}
+                except json.JSONDecodeError:
+                    pass
             matches.append(match_data)
         return matches

--- a/src/chonkie/handshakes/mongodb.py
+++ b/src/chonkie/handshakes/mongodb.py
@@ -134,14 +134,18 @@ class MongoDBHandshake(BaseHandshake):
         return importutil.find_spec("pymongo") is not None
 
     def _generate_document(self, index: int, chunk: Chunk, embedding: list[float]) -> dict:
-        return {
-            "_id": self._generate_id(f"{self.collection_name}::chunk-{index}:{chunk.text}"),
-            "text": chunk.text,
-            "start_index": chunk.start_index,
-            "end_index": chunk.end_index,
-            "token_count": chunk.token_count,
-            "embedding": embedding,
-        }
+        doc_id = self._generate_id(f"{self.collection_name}::chunk-{index}:{chunk.text}")
+        body = self._merge_chunk_metadata(
+            chunk,
+            {
+                "text": chunk.text,
+                "start_index": chunk.start_index,
+                "end_index": chunk.end_index,
+                "token_count": chunk.token_count,
+                "embedding": embedding,
+            },
+        )
+        return {"_id": doc_id, **body}
 
     def write(self, chunks: Union[Chunk, list[Chunk]]) -> None:
         """Write chunks to the MongoDB collection."""
@@ -192,19 +196,7 @@ class MongoDBHandshake(BaseHandshake):
         if query is not None:
             embedding = self.embedding_model.embed(query).tolist()
         # Get all documents with embeddings
-        docs = list(
-            self.collection.find(
-                {},
-                {
-                    "_id": 1,
-                    "text": 1,
-                    "embedding": 1,
-                    "start_index": 1,
-                    "end_index": 1,
-                    "token_count": 1,
-                },
-            ),
-        )
+        docs = list(self.collection.find({}))
 
         def cosine_similarity(a: list[float], b: list[float]) -> float:
             """Compute cosine similarity between two vectors."""
@@ -223,14 +215,14 @@ class MongoDBHandshake(BaseHandshake):
             emb = doc.get("embedding")
             if emb is not None:
                 score = cosine_similarity(embedding, emb)  # type: ignore[arg-type]
-                result = {
+                result: dict[str, Any] = {
                     "id": doc["_id"],
                     "score": score,
-                    "text": doc["text"],
-                    "start_index": doc.get("start_index"),
-                    "end_index": doc.get("end_index"),
-                    "token_count": doc.get("token_count"),
                 }
+                for key, val in doc.items():
+                    if key in ("_id", "embedding"):
+                        continue
+                    result[key] = val
                 results.append(result)
         # Sort by score descending and return limit
         results.sort(key=lambda x: x["score"], reverse=True)

--- a/src/chonkie/handshakes/pgvector.py
+++ b/src/chonkie/handshakes/pgvector.py
@@ -143,7 +143,7 @@ class PgvectorHandshake(BaseHandshake):
         if hasattr(chunk, "language") and chunk.language:
             metadata["language"] = cast(str, chunk.language)
 
-        return metadata
+        return self._merge_chunk_metadata(chunk, metadata)
 
     def write(self, chunks: Union[Chunk, list[Chunk]]) -> list[str]:
         """Write chunks to the PostgreSQL database using vecs.

--- a/src/chonkie/handshakes/pinecone.py
+++ b/src/chonkie/handshakes/pinecone.py
@@ -123,13 +123,17 @@ class PineconeHandshake(BaseHandshake):
     def _is_available(cls) -> bool:
         return importutil.find_spec("pinecone") is not None
 
-    def _generate_metadata(self, chunk: Chunk) -> dict:
-        return {
-            "text": chunk.text,
-            "start_index": chunk.start_index,
-            "end_index": chunk.end_index,
-            "token_count": chunk.token_count,
-        }
+    def _generate_metadata(self, chunk: Chunk) -> dict[str, Any]:
+        merged = self._merge_chunk_metadata(
+            chunk,
+            {
+                "text": chunk.text,
+                "start_index": chunk.start_index,
+                "end_index": chunk.end_index,
+                "token_count": chunk.token_count,
+            },
+        )
+        return self._coerce_flat_metadata(merged)
 
     def _get_vectors(
         self,

--- a/src/chonkie/handshakes/qdrant.py
+++ b/src/chonkie/handshakes/qdrant.py
@@ -132,12 +132,15 @@ class QdrantHandshake(BaseHandshake):
 
     def _generate_payload(self, chunk: Chunk) -> dict:
         """Generate the payload for the chunk."""
-        return {
-            "text": chunk.text,
-            "start_index": chunk.start_index,
-            "end_index": chunk.end_index,
-            "token_count": chunk.token_count,
-        }
+        return self._merge_chunk_metadata(
+            chunk,
+            {
+                "text": chunk.text,
+                "start_index": chunk.start_index,
+                "end_index": chunk.end_index,
+                "token_count": chunk.token_count,
+            },
+        )
 
     def _get_points(self, chunks: Union[Chunk, list[Chunk]]) -> list["PointStruct"]:
         """Get the points from the chunks."""

--- a/src/chonkie/handshakes/turbopuffer.py
+++ b/src/chonkie/handshakes/turbopuffer.py
@@ -1,6 +1,7 @@
 """Turbopuffer Handshake to export Chonkie's Chunks into a Turbopuffer database."""
 
 import importlib.util as importutil
+import json
 import os
 from typing import Any, Literal, Optional, Union
 
@@ -102,6 +103,10 @@ class TurbopufferHandshake(BaseHandshake):
         start_indices = [chunk.start_index for chunk in chunks]
         end_indices = [chunk.end_index for chunk in chunks]
         token_counts = [chunk.token_count for chunk in chunks]
+        chunk_metadata = [
+            json.dumps(chunk.metadata, sort_keys=True) if chunk.metadata else ""
+            for chunk in chunks
+        ]
 
         # Write the chunks to the database
         self.namespace.write(
@@ -112,6 +117,7 @@ class TurbopufferHandshake(BaseHandshake):
                 "start_index": start_indices,
                 "end_index": end_indices,
                 "token_count": token_counts,
+                "chunk_metadata": chunk_metadata,
             },
             distance_metric="cosine_distance",
         )
@@ -151,11 +157,18 @@ class TurbopufferHandshake(BaseHandshake):
         results = self.namespace.query(
             rank_by=("vector", "ANN", embedding),
             top_k=limit,
-            include_attributes=["text", "start_index", "end_index", "token_count"],
+            include_attributes=[
+                "text",
+                "start_index",
+                "end_index",
+                "token_count",
+                "chunk_metadata",
+            ],
         )
         assert results.rows is not None
-        return [
-            {
+        out: list[dict[str, Any]] = []
+        for result in results.rows:
+            row: dict[str, Any] = {
                 "id": result["id"],
                 "score": 1.0 - result["$dist"],
                 "token_count": result["token_count"],
@@ -163,5 +176,13 @@ class TurbopufferHandshake(BaseHandshake):
                 "start_index": result["start_index"],
                 "end_index": result["end_index"],
             }
-            for result in results.rows
-        ]
+            raw_meta = result.get("chunk_metadata")
+            if raw_meta:
+                try:
+                    parsed = json.loads(raw_meta)
+                    if isinstance(parsed, dict):
+                        row = {**parsed, **row}
+                except json.JSONDecodeError:
+                    pass
+            out.append(row)
+        return out

--- a/src/chonkie/handshakes/turbopuffer.py
+++ b/src/chonkie/handshakes/turbopuffer.py
@@ -104,7 +104,7 @@ class TurbopufferHandshake(BaseHandshake):
         end_indices = [chunk.end_index for chunk in chunks]
         token_counts = [chunk.token_count for chunk in chunks]
         chunk_metadata = [
-            json.dumps(chunk.metadata, sort_keys=True) if chunk.metadata else ""
+            json.dumps(chunk.metadata, sort_keys=True, default=str) if chunk.metadata else ""
             for chunk in chunks
         ]
 

--- a/src/chonkie/handshakes/weaviate.py
+++ b/src/chonkie/handshakes/weaviate.py
@@ -1,6 +1,7 @@
 """Weaviate Handshake to export Chonkie's Chunks into a Weaviate collection."""
 
 import importlib.util as importutil
+import json
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -243,6 +244,11 @@ class WeaviateHandshake(BaseHandshake):
                         "data_type": DataType.TEXT,
                         "description": "The type of the chunk",
                     }),
+                    Property.model_validate({
+                        "name": "chunk_metadata",
+                        "data_type": DataType.TEXT,
+                        "description": "JSON-serialized :attr:`~chonkie.types.Chunk.metadata`",
+                    }),
                 ],
             )
 
@@ -279,6 +285,11 @@ class WeaviateHandshake(BaseHandshake):
 
         if hasattr(chunk, "language") and chunk.language:
             properties["language"] = str(chunk.language)
+
+        if chunk.metadata:
+            properties["chunk_metadata"] = json.dumps(chunk.metadata, sort_keys=True)
+        else:
+            properties["chunk_metadata"] = ""
 
         return properties
 
@@ -390,6 +401,7 @@ class WeaviateHandshake(BaseHandshake):
             "end_index",
             "token_count",
             "chunk_type",
+            "chunk_metadata",
         ]
 
         if hasattr(schema, "properties") and schema.properties:
@@ -464,7 +476,7 @@ class WeaviateHandshake(BaseHandshake):
             score = getattr(obj.metadata, "distance", None) if obj.metadata else None
             # Weaviate returns distance, convert to similarity (1 - distance) if needed
             similarity = 1.0 - score if score is not None else None
-            match = {
+            match: dict[str, Any] = {
                 "id": obj.uuid,
                 "score": similarity,
                 "text": obj.properties.get("text"),
@@ -473,6 +485,14 @@ class WeaviateHandshake(BaseHandshake):
                 "token_count": obj.properties.get("token_count"),
                 "chunk_type": obj.properties.get("chunk_type"),
             }
+            raw_meta = obj.properties.get("chunk_metadata")
+            if raw_meta:
+                try:
+                    parsed = json.loads(raw_meta)
+                    if isinstance(parsed, dict):
+                        match = {**parsed, **match}
+                except json.JSONDecodeError:
+                    pass
             matches.append(match)
         logger.info(f"Search complete: found {len(matches)} matching chunks")
         return matches

--- a/src/chonkie/handshakes/weaviate.py
+++ b/src/chonkie/handshakes/weaviate.py
@@ -287,7 +287,7 @@ class WeaviateHandshake(BaseHandshake):
             properties["language"] = str(chunk.language)
 
         if chunk.metadata:
-            properties["chunk_metadata"] = json.dumps(chunk.metadata, sort_keys=True)
+            properties["chunk_metadata"] = json.dumps(chunk.metadata, sort_keys=True, default=str)
         else:
             properties["chunk_metadata"] = ""
 

--- a/src/chonkie/handshakes/weaviate.py
+++ b/src/chonkie/handshakes/weaviate.py
@@ -486,7 +486,7 @@ class WeaviateHandshake(BaseHandshake):
                 "chunk_type": obj.properties.get("chunk_type"),
             }
             raw_meta = obj.properties.get("chunk_metadata")
-            if raw_meta:
+            if isinstance(raw_meta, (str, bytes, bytearray)) and raw_meta:
                 try:
                     parsed = json.loads(raw_meta)
                     if isinstance(parsed, dict):

--- a/src/chonkie/types/base.py
+++ b/src/chonkie/types/base.py
@@ -1,7 +1,7 @@
 """Custom base types for Chonkie."""
 
 from dataclasses import dataclass, field
-from typing import Iterator, Optional, Union
+from typing import Any, Iterator, Optional, Union
 from uuid import uuid4
 
 import numpy as np
@@ -25,6 +25,9 @@ class Chunk:
         context (Optional[str]): Optional context metadata for the chunk.
         embedding (Union[list[float], np.ndarray, None]): Optional embedding vector for the chunk,
             either as a list of floats or a numpy array.
+        metadata (dict[str, Any]): Arbitrary per-chunk metadata; ``BaseChunker.chunk_document``
+            merges in the parent :class:`~chonkie.types.Document` metadata (chunk keys win
+            on duplicate keys).
 
     """
 
@@ -35,6 +38,7 @@ class Chunk:
     token_count: int = field(default=0)
     context: Optional[str] = field(default=None)
     embedding: Union[list[float], np.ndarray, None] = field(default=None)
+    metadata: dict[str, Any] = field(default_factory=dict)
 
     def __len__(self) -> int:
         """Return the length of the text."""
@@ -121,6 +125,7 @@ class Chunk:
             token_count=data["token_count"],
             context=data.get("context", None),
             embedding=data.get("embedding", None),
+            metadata=dict(data.get("metadata") or {}),
         )
 
     def copy(self) -> "Chunk":

--- a/tests/chef/test_chef.py
+++ b/tests/chef/test_chef.py
@@ -41,6 +41,7 @@ class TestTextChef:
                     assert all(r.content == sample_text for r in result)
                 else:
                     assert result.content == sample_text
+                    assert result.metadata["filename"] == "test_file.txt"
 
     def test_process_single_file_path_object(
         self: "TestTextChef",
@@ -55,6 +56,7 @@ class TestTextChef:
                 assert all(r.content == sample_text for r in result)
             else:
                 assert result.content == sample_text
+                assert result.metadata["filename"] == "test_file.txt"
 
     def test_process_batch_string_paths(
         self: "TestTextChef",
@@ -67,6 +69,11 @@ class TestTextChef:
             results = text_chef.process_batch(paths)
             assert len(results) == 3
             assert all(result.content == sample_text for result in results)
+            assert [r.metadata["filename"] for r in results] == [
+                "file1.txt",
+                "file2.txt",
+                "file3.txt",
+            ]
 
     def test_process_batch_path_objects(
         self: "TestTextChef",
@@ -79,6 +86,11 @@ class TestTextChef:
             results = text_chef.process_batch(paths)
             assert len(results) == 3
             assert all(result.content == sample_text for result in results)
+            assert [r.metadata["filename"] for r in results] == [
+                "file1.txt",
+                "file2.txt",
+                "file3.txt",
+            ]
 
     def test_process_batch_mixed_path_types(
         self: "TestTextChef",
@@ -91,6 +103,11 @@ class TestTextChef:
             results = text_chef.process_batch([str(p) for p in paths])
             assert len(results) == 3
             assert all(result.content == sample_text for result in results)
+            assert [r.metadata["filename"] for r in results] == [
+                "file1.txt",
+                "file2.txt",
+                "file3.txt",
+            ]
 
     def test_call_single_string_path(
         self: "TestTextChef",
@@ -106,6 +123,7 @@ class TestTextChef:
             else:
                 assert result.content == sample_text
                 assert isinstance(result, Document)
+                assert result.metadata["filename"] == "test_file.txt"
 
     def test_call_single_path_object(
         self: "TestTextChef",
@@ -121,6 +139,7 @@ class TestTextChef:
             else:
                 assert result.content == sample_text
                 assert isinstance(result, Document)
+                assert result.metadata["filename"] == "test_file.txt"
 
     def test_call_list_of_strings(
         self: "TestTextChef",
@@ -134,6 +153,7 @@ class TestTextChef:
             assert isinstance(results, list)
             assert len(results) == 2
             assert all(result.content == sample_text for result in results)
+            assert [r.metadata["filename"] for r in results] == ["file1.txt", "file2.txt"]
 
     def test_call_list_of_path_objects(
         self: "TestTextChef",
@@ -147,6 +167,7 @@ class TestTextChef:
             assert isinstance(results, list)
             assert len(results) == 2
             assert all(result.content == sample_text for result in results)
+            assert [r.metadata["filename"] for r in results] == ["file1.txt", "file2.txt"]
 
     def test_call_tuple_of_paths(
         self: "TestTextChef",
@@ -160,6 +181,7 @@ class TestTextChef:
             assert isinstance(results, list)
             assert len(results) == 2
             assert all(result.content == sample_text for result in results)
+            assert [r.metadata["filename"] for r in results] == ["file1.txt", "file2.txt"]
 
     def test_call_invalid_type_raises_error(self: "TestTextChef", text_chef: TextChef) -> None:
         """Test __call__ method with invalid input type raises TypeError."""
@@ -191,6 +213,7 @@ class TestTextChef:
         with patch("builtins.open", mock_open(read_data="")):
             result = text_chef.process("empty_file.txt")
             assert result.content == ""
+            assert result.metadata["filename"] == "empty_file.txt"
 
     def test_file_with_unicode_content(self: "TestTextChef", text_chef: TextChef) -> None:
         """Test processing file with unicode content."""
@@ -198,6 +221,13 @@ class TestTextChef:
         with patch("builtins.open", mock_open(read_data=unicode_text)):
             result = text_chef.process("unicode_file.txt")
             assert result.content == unicode_text
+            assert result.metadata["filename"] == "unicode_file.txt"
+
+    def test_parse_does_not_set_source_filename(self: "TestTextChef", text_chef: TextChef) -> None:
+        """parse() has no file path, so metadata must not include a synthetic filename."""
+        result = text_chef.parse("hello")
+        assert result.content == "hello"
+        assert "filename" not in result.metadata
 
     def test_repr_method(self: "TestTextChef", text_chef: TextChef) -> None:
         """Test __repr__ method returns correct string."""

--- a/tests/chef/test_markdown_chef.py
+++ b/tests/chef/test_markdown_chef.py
@@ -179,6 +179,7 @@ Conclusion text."""
         assert len(result.tables) == 0
         assert len(result.code) == 0
         assert len(result.images) == 0
+        assert "filename" not in result.metadata
 
     def test_parse_whitespace_only(self, markdown_chef: MarkdownChef) -> None:
         """Test parsing whitespace-only string."""
@@ -333,6 +334,7 @@ This is not a valid table."""
 
             assert isinstance(result, MarkdownDocument)
             assert result.content == simple_markdown
+            assert result.metadata["filename"] == "test.md"
 
     def test_process_file_with_path_object(
         self,
@@ -346,6 +348,7 @@ This is not a valid table."""
 
             assert isinstance(result, MarkdownDocument)
             assert result.content == simple_markdown
+            assert result.metadata["filename"] == "test.md"
 
     def test_process_calls_parse(self, markdown_chef: MarkdownChef, simple_markdown: str) -> None:
         """Test that process() calls parse() internally."""
@@ -371,6 +374,11 @@ This is not a valid table."""
             assert len(results) == 3
             assert all(isinstance(r, MarkdownDocument) for r in results)
             assert all(r.content == simple_markdown for r in results)
+            assert [r.metadata["filename"] for r in results] == [
+                "file1.md",
+                "file2.md",
+                "file3.md",
+            ]
 
     # ==================== Edge Cases ====================
 

--- a/tests/chef/test_table_chef.py
+++ b/tests/chef/test_table_chef.py
@@ -69,6 +69,7 @@ class TestTableChef:
             "1" in content_str and "2" in content_str and "3" in content_str and "4" in content_str
         )
         assert called["called"]
+        assert result.metadata["filename"] == "test.csv"
 
     def test_process_excel_file(
         self: "TestTableChef",
@@ -98,6 +99,7 @@ class TestTableChef:
             "1" in content_str and "2" in content_str and "3" in content_str and "4" in content_str
         )
         assert called["called"]
+        assert result.metadata["filename"] == "test.xlsx"
 
     def test_process_markdown_table_string(
         self: "TestTableChef",
@@ -109,6 +111,7 @@ class TestTableChef:
         assert isinstance(result, MarkdownDocument)
         assert len(result.tables) == 1
         assert hasattr(result.tables[0], "content")
+        assert "filename" not in result.metadata
 
     def test_process_batch(
         self: "TestTableChef",
@@ -124,6 +127,7 @@ class TestTableChef:
         results = table_chef.process_batch([file1, file2])
         assert isinstance(results, list)
         assert len(results) == 2
+        assert [r.metadata["filename"] for r in results] == ["a.csv", "b.csv"]
         for r in results:
             if hasattr(r, "content"):
                 content_str = str(r.content)
@@ -155,6 +159,7 @@ class TestTableChef:
         results = table_chef([file1, file2])
         assert isinstance(results, list)
         assert len(results) == 2
+        assert [r.metadata["filename"] for r in results] == ["a.csv", "b.csv"]
         for r in results:
             if hasattr(r, "content"):
                 content_str = str(r.content)
@@ -188,6 +193,7 @@ class TestTableChef:
         assert (
             "1" in content_str and "2" in content_str and "3" in content_str and "4" in content_str
         )
+        assert result.metadata["filename"] == "a.csv"
 
     def test_call_invalid_type(self: "TestTableChef", table_chef: TableChef) -> None:
         """Test that TableChef raises TypeError on invalid input type."""

--- a/tests/chunkers/test_recursive_chunker.py
+++ b/tests/chunkers/test_recursive_chunker.py
@@ -15,6 +15,7 @@ import pytest
 
 from chonkie import (
     Chunk,
+    Document,
     RecursiveChunker,
     RecursiveLevel,
     RecursiveRules,
@@ -513,3 +514,26 @@ def test_recursive_chunker_cjk_default_rules_reconstruction(
     chunks = chunker.chunk(cjk_text)
     assert len(chunks) > 0
     assert cjk_text == "".join(chunk.text for chunk in chunks)
+
+
+def test_chunk_document_propagates_metadata(
+    sample_text: str,
+    default_rules: RecursiveRules,
+) -> None:
+    """Document metadata is merged into every chunk (chunk keys win on conflict)."""
+    chunker = RecursiveChunker(rules=default_rules, chunk_size=512, min_characters_per_chunk=1)
+    doc = Document(
+        content=sample_text[:2000],
+        metadata={"filename": "paper.md", "source": "test"},
+    )
+    chunker.chunk_document(doc)
+    assert doc.chunks
+    for c in doc.chunks:
+        assert c.metadata["filename"] == "paper.md"
+        assert c.metadata["source"] == "test"
+
+    doc.chunks[0].metadata["filename"] = "override.md"
+    assert doc.chunks[0].metadata["filename"] == "override.md"
+    chunker.chunk_document(doc)
+    assert doc.chunks[0].metadata["filename"] == "paper.md"
+    assert doc.chunks[0].metadata["source"] == "test"

--- a/tests/handshakes/test_base_handshake.py
+++ b/tests/handshakes/test_base_handshake.py
@@ -1,0 +1,30 @@
+"""Tests for BaseHandshake helpers."""
+
+from chonkie.handshakes.base import BaseHandshake
+from chonkie.types import Chunk
+
+
+def test_merge_chunk_metadata_precedence() -> None:
+    """Handshake fields override keys present in chunk.metadata."""
+    chunk = Chunk(
+        text="hi",
+        start_index=0,
+        end_index=2,
+        token_count=1,
+        metadata={"filename": "a.txt", "token_count": 999},
+    )
+    merged = BaseHandshake._merge_chunk_metadata(
+        chunk,
+        {"text": chunk.text, "token_count": chunk.token_count},
+    )
+    assert merged["filename"] == "a.txt"
+    assert merged["token_count"] == chunk.token_count
+
+
+def test_coerce_flat_metadata() -> None:
+    """Non-primitive metadata values become JSON strings."""
+    merged = {"a": 1, "b": [1, 2], "c": "ok"}
+    flat = BaseHandshake._coerce_flat_metadata(merged)
+    assert flat["a"] == 1
+    assert flat["c"] == "ok"
+    assert flat["b"] == "[1, 2]"

--- a/tests/handshakes/test_lancedb_handshake.py
+++ b/tests/handshakes/test_lancedb_handshake.py
@@ -264,6 +264,7 @@ def test_generate_row(sample_chunk: Chunk, real_embeddings: BaseEmbeddings) -> N
     assert row["start_index"] == sample_chunk.start_index
     assert row["end_index"] == sample_chunk.end_index
     assert row["token_count"] == sample_chunk.token_count
+    assert row["chunk_metadata"] == ""
     assert row["vector"] == embedding
 
 

--- a/tests/handshakes/test_milvus_handshake.py
+++ b/tests/handshakes/test_milvus_handshake.py
@@ -130,11 +130,12 @@ def test_write_multiple_chunks(mock_pymilvus_modules, mock_embeddings, sample_ch
     # Verify the data was passed in the correct columnar format
     args, _ = handshake.collection.insert.call_args
     inserted_data = args[0]
-    assert len(inserted_data) == 5  # pk (auto) + 4 metadata fields + embedding
+    assert len(inserted_data) == 6  # text, indices, token_count, chunk_metadata, embedding
     # Check texts
     assert inserted_data[0] == [c.text for c in sample_chunks]
+    assert inserted_data[4] == ["", ""]
     # Check embeddings
-    assert np.array_equal(inserted_data[4], mock_embeddings.embed_batch.return_value)
+    assert np.array_equal(inserted_data[5], mock_embeddings.embed_batch.return_value)
 
 
 def test_search_with_query(mock_pymilvus_modules, mock_embeddings):

--- a/tests/handshakes/test_qdrant_handshake.py
+++ b/tests/handshakes/test_qdrant_handshake.py
@@ -380,3 +380,28 @@ def test_generate_payload(sample_chunk: Chunk, real_embeddings: BaseEmbeddings) 
     }
     # Cleanup client implicitly created by handshake
     handshake.client.delete_collection(collection_name="test-payload-gen-real")
+
+
+def test_qdrant_chunk_metadata_roundtrip(real_embeddings: BaseEmbeddings) -> None:
+    """Chunk.metadata is stored in the payload and returned by search."""
+    collection_name = "test-metadata-roundtrip"
+    client = qdrant_client.QdrantClient(":memory:")
+    handshake = QdrantHandshake(
+        client=client,
+        collection_name=collection_name,
+        embedding_model=real_embeddings,
+    )
+    chunk = Chunk(
+        text="metadata roundtrip text",
+        start_index=0,
+        end_index=25,
+        token_count=4,
+        metadata={"filename": "readme.md", "source": "test"},
+    )
+    handshake.write(chunk)
+    hits = handshake.search(query=chunk.text, limit=3)
+    assert len(hits) >= 1
+    assert hits[0]["filename"] == "readme.md"
+    assert hits[0]["source"] == "test"
+    assert hits[0]["text"] == chunk.text
+    client.delete_collection(collection_name=collection_name)

--- a/tests/handshakes/test_weaviate_handshake.py
+++ b/tests/handshakes/test_weaviate_handshake.py
@@ -201,6 +201,7 @@ def test_weaviate_handshake_generate_properties(mock_weaviate_client) -> None:
         "end_index": chunk.end_index,
         "token_count": chunk.token_count,
         "chunk_type": type(chunk).__name__,
+        "chunk_metadata": "",
     }
     generated_properties = handshake._generate_properties(chunk)
     assert generated_properties == expected_properties

--- a/tests/porters/test_datasets_porter.py
+++ b/tests/porters/test_datasets_porter.py
@@ -55,6 +55,7 @@ def test_dataset_structure_and_content(sample_chunks):  # noqa
         "token_count",
         "context",
         "embedding",
+        "metadata",
     }
     assert set(ds.column_names) == expected_columns
     # Check content
@@ -65,6 +66,7 @@ def test_dataset_structure_and_content(sample_chunks):  # noqa
         assert row["end_index"] == chunk.end_index
         assert row["token_count"] == chunk.token_count
         assert row["context"] is None
+        assert row["metadata"] == chunk.metadata
 
 
 @patch("datasets.Dataset.save_to_disk")

--- a/tests/types/test_base.py
+++ b/tests/types/test_base.py
@@ -45,12 +45,14 @@ def test_chunk_serialization():
         end_index=10,
         token_count=2,
         context="context string",
+        metadata={"filename": "a.md"},
     )
     chunk_dict = chunk.to_dict()
     restored = Chunk.from_dict(chunk_dict)
     assert chunk.text == restored.text
     assert chunk.token_count == restored.token_count
     assert chunk.context == restored.context
+    assert restored.metadata == {"filename": "a.md"}
 
 
 def test_chunk_with_embedding():


### PR DESCRIPTION
this pr is inspired by https://github.com/chonkie-inc/chonkie/issues/551#issuecomment-4252340649 and it allows us to capture and store file metadata in Chefs.

## examples
```python
from chonkie import TextChef, RecursiveChunker, QdrantHandshake
from pathlib import Path

chef = TextChef()
chunker = RecursiveChunker(chunk_size=512)
handshake = QdrantHandshake(collection_name="test")


doc = chef.process(Path("../README.md")) 
print(doc.metadata["filename"])   # "README.md"

chunked_doc = chunker.chunk_document(doc)
chunks =chunked_doc.chunks
handshake.write(chunks)
handshake.search("hippo") # outputs with filename field
```

```python
from chonkie.pipeline import Pipeline

docs = (
    Pipeline()
    .fetch_from("file", dir="../docs", ext=[".mdx"])
    .process_with("markdown")
    .chunk_with("recursive", chunk_size=512)
    .run()
)

chunks_out = []
for doc in docs:
    source_name = doc.metadata["filename"]  # e.g. "chapter1.mdx"
    for chunk in doc.chunks:
        chunks_out.append({"source": source_name, "text": chunk.text})
```
this is still a WIP, and this feature is not mature enough, i will continue refining it to make it useful for real world scenarios 