### PR TITLE
feat: MarkdownDocument support for CodeChunker + TableChunker no-op fix

### DIFF
--- a/src/chonkie/chunker/code.py
+++ b/src/chonkie/chunker/code.py
@@ -376,11 +376,14 @@ class CodeChunker(BaseChunker):
             try:
                 parser = get_parser(cast(SupportedLanguage, language))
                 original_parser = self.parser
+                original_language = self.language
                 self.parser = parser
+                self.language = language
                 try:
                     return self.chunk(content)
                 finally:
                     self.parser = original_parser
+                    self.language = original_language
             except Exception:
                 pass
         return self.chunk(content)
@@ -398,7 +401,9 @@ class CodeChunker(BaseChunker):
                     # (including ```lang and ```), but content is the inner code.
                     # Compute the actual content offset within the document.
                     fenced_block = document.content[code_block.start_index : code_block.end_index]
-                    content_offset = fenced_block.find(code_block.content)
+                    first_newline = fenced_block.find("\n")
+                    search_start = first_newline if first_newline != -1 else 0
+                    content_offset = fenced_block.find(code_block.content, search_start)
                     if content_offset == -1:
                         content_start = code_block.start_index
                     else:

--- a/src/chonkie/chunker/code.py
+++ b/src/chonkie/chunker/code.py
@@ -384,8 +384,8 @@ class CodeChunker(BaseChunker):
                 finally:
                     self.parser = original_parser
                     self.language = original_language
-            except Exception:
-                pass
+            except Exception as e:
+                logger.debug(f"Language hint '{language}' failed, falling back to auto: {e}")
         return self.chunk(content)
 
     def chunk_document(self, document: Document) -> Document:
@@ -397,17 +397,14 @@ class CodeChunker(BaseChunker):
                     if not code_block.content.strip():
                         continue
 
-                    # MarkdownChef sets start_index/end_index to the full fenced block
-                    # (including ```lang and ```), but content is the inner code.
-                    # Compute the actual content offset within the document.
+                    # Fenced block indices include the ``` delimiters; content starts after first newline.
                     fenced_block = document.content[code_block.start_index : code_block.end_index]
                     first_newline = fenced_block.find("\n")
-                    search_start = first_newline if first_newline != -1 else 0
-                    content_offset = fenced_block.find(code_block.content, search_start)
-                    if content_offset == -1:
-                        content_start = code_block.start_index
-                    else:
-                        content_start = code_block.start_index + content_offset
+                    content_start = (
+                        code_block.start_index + first_newline + 1
+                        if first_newline != -1
+                        else code_block.start_index
+                    )
 
                     try:
                         chunks = self._chunk_code_block(code_block.content, code_block.language)

--- a/src/chonkie/chunker/code.py
+++ b/src/chonkie/chunker/code.py
@@ -382,12 +382,14 @@ class CodeChunker(BaseChunker):
                         logger.warning(
                             f"CodeChunker failed for code block at index {code_block.start_index}: {e}"
                         )
-                        chunks = [Chunk(
-                            text=code_block.content,
-                            start_index=0,
-                            end_index=len(code_block.content),
-                            token_count=self.tokenizer.count_tokens(code_block.content),
-                        )]
+                        chunks = [
+                            Chunk(
+                                text=code_block.content,
+                                start_index=0,
+                                end_index=len(code_block.content),
+                                token_count=self.tokenizer.count_tokens(code_block.content),
+                            )
+                        ]
                     for chunk in chunks:
                         chunk.start_index = code_block.start_index + chunk.start_index
                         chunk.end_index = code_block.start_index + chunk.end_index
@@ -395,10 +397,7 @@ class CodeChunker(BaseChunker):
                 document.chunks.sort(key=lambda x: x.start_index)
             BaseChunker._propagate_document_metadata(document)
             return document
-        document.chunks = self.chunk(document.content)
-        logger.info(f"Document chunking complete: {len(document.chunks)} chunks created")
-        BaseChunker._propagate_document_metadata(document)
-        return document
+        return super().chunk_document(document)
 
     def __repr__(self) -> str:
         """Return the string representation of the CodeChunker."""

--- a/src/chonkie/chunker/code.py
+++ b/src/chonkie/chunker/code.py
@@ -12,7 +12,7 @@ from chonkie.chunker.base import BaseChunker
 from chonkie.logger import get_logger
 from chonkie.pipeline import chunker
 from chonkie.tokenizer import TokenizerProtocol
-from chonkie.types import Chunk
+from chonkie.types import Chunk, Document, MarkdownDocument
 
 logger = get_logger(__name__)
 
@@ -367,6 +367,38 @@ class CodeChunker(BaseChunker):
         chunks = self._create_chunks(texts, token_counts, node_groups)
         logger.info(f"Created {len(chunks)} code chunks from parsed syntax tree")
         return chunks
+
+    def chunk_document(self, document: Document) -> Document:
+        """Chunk a document, with special handling for MarkdownDocument code blocks."""
+        if isinstance(document, MarkdownDocument):
+            if document.code:
+                logger.debug(f"Processing MarkdownDocument with {len(document.code)} code blocks")
+                for code_block in document.code:
+                    if not code_block.content.strip():
+                        continue
+                    try:
+                        chunks = self.chunk(code_block.content)
+                    except Exception as e:
+                        logger.warning(
+                            f"CodeChunker failed for code block at index {code_block.start_index}: {e}"
+                        )
+                        chunks = [Chunk(
+                            text=code_block.content,
+                            start_index=0,
+                            end_index=len(code_block.content),
+                            token_count=self.tokenizer.count_tokens(code_block.content),
+                        )]
+                    for chunk in chunks:
+                        chunk.start_index = code_block.start_index + chunk.start_index
+                        chunk.end_index = code_block.start_index + chunk.end_index
+                    document.chunks.extend(chunks)
+                document.chunks.sort(key=lambda x: x.start_index)
+            BaseChunker._propagate_document_metadata(document)
+            return document
+        document.chunks = self.chunk(document.content)
+        logger.info(f"Document chunking complete: {len(document.chunks)} chunks created")
+        BaseChunker._propagate_document_metadata(document)
+        return document
 
     def __repr__(self) -> str:
         """Return the string representation of the CodeChunker."""

--- a/src/chonkie/chunker/code.py
+++ b/src/chonkie/chunker/code.py
@@ -371,10 +371,10 @@ class CodeChunker(BaseChunker):
     def _chunk_code_block(self, content: str, language: str | None) -> list[Chunk]:
         """Chunk a single code block, using the block's language hint when available."""
         if language and self.language == "auto":
-            from tree_sitter_language_pack import get_parser
+            from tree_sitter_language_pack import SupportedLanguage, get_parser
 
             try:
-                parser = get_parser(language)
+                parser = get_parser(cast(SupportedLanguage, language))
                 original_parser = self.parser
                 self.parser = parser
                 try:

--- a/src/chonkie/chunker/code.py
+++ b/src/chonkie/chunker/code.py
@@ -368,6 +368,23 @@ class CodeChunker(BaseChunker):
         logger.info(f"Created {len(chunks)} code chunks from parsed syntax tree")
         return chunks
 
+    def _chunk_code_block(self, content: str, language: str | None) -> list[Chunk]:
+        """Chunk a single code block, using the block's language hint when available."""
+        if language and self.language == "auto":
+            from tree_sitter_language_pack import get_parser
+
+            try:
+                parser = get_parser(language)
+                original_parser = self.parser
+                self.parser = parser
+                try:
+                    return self.chunk(content)
+                finally:
+                    self.parser = original_parser
+            except Exception:
+                pass
+        return self.chunk(content)
+
     def chunk_document(self, document: Document) -> Document:
         """Chunk a document, with special handling for MarkdownDocument code blocks."""
         if isinstance(document, MarkdownDocument):
@@ -376,8 +393,19 @@ class CodeChunker(BaseChunker):
                 for code_block in document.code:
                     if not code_block.content.strip():
                         continue
+
+                    # MarkdownChef sets start_index/end_index to the full fenced block
+                    # (including ```lang and ```), but content is the inner code.
+                    # Compute the actual content offset within the document.
+                    fenced_block = document.content[code_block.start_index : code_block.end_index]
+                    content_offset = fenced_block.find(code_block.content)
+                    if content_offset == -1:
+                        content_start = code_block.start_index
+                    else:
+                        content_start = code_block.start_index + content_offset
+
                     try:
-                        chunks = self.chunk(code_block.content)
+                        chunks = self._chunk_code_block(code_block.content, code_block.language)
                     except Exception as e:
                         logger.warning(
                             f"CodeChunker failed for code block at index {code_block.start_index}: {e}"
@@ -391,8 +419,8 @@ class CodeChunker(BaseChunker):
                             )
                         ]
                     for chunk in chunks:
-                        chunk.start_index = code_block.start_index + chunk.start_index
-                        chunk.end_index = code_block.start_index + chunk.end_index
+                        chunk.start_index = content_start + chunk.start_index
+                        chunk.end_index = content_start + chunk.end_index
                     document.chunks.extend(chunks)
                 document.chunks.sort(key=lambda x: x.start_index)
             BaseChunker._propagate_document_metadata(document)

--- a/src/chonkie/chunker/table.py
+++ b/src/chonkie/chunker/table.py
@@ -242,18 +242,20 @@ class TableChunker(BaseChunker):
         logger.debug(
             f"Chunking document with {len(document.content) if hasattr(document, 'content') else 0} characters",
         )
-        if isinstance(document, MarkdownDocument) and document.tables:
-            logger.debug(f"Processing MarkdownDocument with {len(document.tables)} tables")
-            for table in document.tables:
-                chunks = self.chunk(table.content)
-                for chunk in chunks:
-                    chunk.start_index = table.start_index + chunk.start_index
-                    chunk.end_index = table.start_index + chunk.end_index
-                document.chunks.extend(chunks)
-            document.chunks.sort(key=lambda x: x.start_index)
-        else:
-            document.chunks = self.chunk(document.content)
-            document.chunks.sort(key=lambda x: x.start_index)
+        if isinstance(document, MarkdownDocument):
+            if document.tables:
+                logger.debug(f"Processing MarkdownDocument with {len(document.tables)} tables")
+                for table in document.tables:
+                    chunks = self.chunk(table.content)
+                    for chunk in chunks:
+                        chunk.start_index = table.start_index + chunk.start_index
+                        chunk.end_index = table.start_index + chunk.end_index
+                    document.chunks.extend(chunks)
+                document.chunks.sort(key=lambda x: x.start_index)
+            BaseChunker._propagate_document_metadata(document)
+            return document
+        document.chunks = self.chunk(document.content)
+        document.chunks.sort(key=lambda x: x.start_index)
         logger.info(f"Document chunking complete: {len(document.chunks)} chunks created")
         BaseChunker._propagate_document_metadata(document)
         return document

--- a/src/chonkie/chunker/table.py
+++ b/src/chonkie/chunker/table.py
@@ -254,11 +254,7 @@ class TableChunker(BaseChunker):
                 document.chunks.sort(key=lambda x: x.start_index)
             BaseChunker._propagate_document_metadata(document)
             return document
-        document.chunks = self.chunk(document.content)
-        document.chunks.sort(key=lambda x: x.start_index)
-        logger.info(f"Document chunking complete: {len(document.chunks)} chunks created")
-        BaseChunker._propagate_document_metadata(document)
-        return document
+        return super().chunk_document(document)
 
     def __repr__(self) -> str:
         """Return a string representation of the TableChunker."""

--- a/tests/chunkers/test_code_chunker.py
+++ b/tests/chunkers/test_code_chunker.py
@@ -232,7 +232,7 @@ def test_code_chunker_markdown_document_empty_code() -> None:
 
 
 def test_code_chunker_markdown_document_no_code() -> None:
-    """Test that CodeChunker with MarkdownDocument falls through when no code blocks."""
+    """Test that CodeChunker is a no-op on MarkdownDocument with no code blocks."""
     doc = MarkdownDocument(
         content="# Title\n\nSome text.\n",
         chunks=[Chunk(text="Some text.", start_index=10, end_index=20, token_count=2)],
@@ -242,8 +242,9 @@ def test_code_chunker_markdown_document_no_code() -> None:
     chunker = CodeChunker(language="python", chunk_size=50)
     result = chunker.chunk_document(doc)
 
-    # Should fall through to base class behavior (re-chunk existing chunks)
-    assert len(result.chunks) >= 1
+    # Existing chunks should be preserved untouched
+    assert len(result.chunks) == 1
+    assert result.chunks[0].text == "Some text."
 
 
 def test_code_chunker_plain_document() -> None:

--- a/tests/chunkers/test_code_chunker.py
+++ b/tests/chunkers/test_code_chunker.py
@@ -4,6 +4,7 @@ import pytest
 
 from chonkie import CodeChunker
 from chonkie.types import Chunk
+from chonkie.types.markdown import MarkdownCode, MarkdownDocument
 
 
 @pytest.fixture
@@ -169,3 +170,82 @@ def test_code_chunker_chunk_size_javascript(js_code: str) -> None:
     # Allow for some leeway
     assert all(chunk.token_count < chunk_size + 15 for chunk in chunks[:-1])
     assert chunks[-1].token_count > 0
+
+
+def test_code_chunker_markdown_document() -> None:
+    """Test that CodeChunker handles MarkdownDocument code blocks."""
+    python_block = 'def hello():\n    print("world")\n\ndef foo():\n    for i in range(100):\n        print(i)\n'
+    js_block = 'function greet(name) {\n  console.log(`Hello, ${name}!`);\n}\n'
+
+    doc = MarkdownDocument(
+        content=f"# Title\n\nSome text.\n\n```python\n{python_block}```\n\nMore text.\n\n```javascript\n{js_block}```\n",
+        chunks=[Chunk(text="Some text.", start_index=10, end_index=20, token_count=2)],
+        code=[
+            MarkdownCode(content=python_block, language="python", start_index=35, end_index=35 + len(python_block)),
+            MarkdownCode(content=js_block, language="javascript", start_index=150, end_index=150 + len(js_block)),
+        ],
+    )
+
+    chunker = CodeChunker(language="auto", chunk_size=50)
+    result = chunker.chunk_document(doc)
+
+    # Original text chunks should be preserved
+    assert any(c.text == "Some text." for c in result.chunks)
+    # Code blocks should be chunked and added
+    assert len(result.chunks) > 1
+    # All code chunk indices should be offset by the code block's start_index
+    code_chunks = [c for c in result.chunks if c.text != "Some text."]
+    assert len(code_chunks) > 0
+    for c in code_chunks:
+        assert c.start_index >= 35
+    # Chunks should be sorted by start_index
+    for i in range(len(result.chunks) - 1):
+        assert result.chunks[i].start_index <= result.chunks[i + 1].start_index
+
+
+def test_code_chunker_markdown_document_empty_code() -> None:
+    """Test that CodeChunker skips empty code blocks in MarkdownDocument."""
+    doc = MarkdownDocument(
+        content="# Title\n\nSome text.\n",
+        chunks=[Chunk(text="Some text.", start_index=10, end_index=20, token_count=2)],
+        code=[
+            MarkdownCode(content="   \n  ", language="python", start_index=50, end_index=60),
+        ],
+    )
+
+    chunker = CodeChunker(language="python", chunk_size=50)
+    result = chunker.chunk_document(doc)
+
+    # Only the original text chunk should remain
+    assert len(result.chunks) == 1
+    assert result.chunks[0].text == "Some text."
+
+
+def test_code_chunker_markdown_document_no_code() -> None:
+    """Test that CodeChunker with MarkdownDocument falls through when no code blocks."""
+    doc = MarkdownDocument(
+        content="# Title\n\nSome text.\n",
+        chunks=[Chunk(text="Some text.", start_index=10, end_index=20, token_count=2)],
+        code=[],
+    )
+
+    chunker = CodeChunker(language="python", chunk_size=50)
+    result = chunker.chunk_document(doc)
+
+    # Should fall through to base class behavior (re-chunk existing chunks)
+    assert len(result.chunks) >= 1
+
+
+def test_code_chunker_plain_document() -> None:
+    """Test that CodeChunker still works with plain Document (non-markdown)."""
+    from chonkie.types import Document
+
+    code = 'def hello():\n    print("world")\n'
+    doc = Document(content=code)
+
+    chunker = CodeChunker(language="python", chunk_size=512)
+    result = chunker.chunk_document(doc)
+
+    assert len(result.chunks) > 0
+    reconstructed = "".join(c.text for c in result.chunks)
+    assert reconstructed == code

--- a/tests/chunkers/test_code_chunker.py
+++ b/tests/chunkers/test_code_chunker.py
@@ -175,14 +175,24 @@ def test_code_chunker_chunk_size_javascript(js_code: str) -> None:
 def test_code_chunker_markdown_document() -> None:
     """Test that CodeChunker handles MarkdownDocument code blocks."""
     python_block = 'def hello():\n    print("world")\n\ndef foo():\n    for i in range(100):\n        print(i)\n'
-    js_block = 'function greet(name) {\n  console.log(`Hello, ${name}!`);\n}\n'
+    js_block = "function greet(name) {\n  console.log(`Hello, ${name}!`);\n}\n"
 
     doc = MarkdownDocument(
         content=f"# Title\n\nSome text.\n\n```python\n{python_block}```\n\nMore text.\n\n```javascript\n{js_block}```\n",
         chunks=[Chunk(text="Some text.", start_index=10, end_index=20, token_count=2)],
         code=[
-            MarkdownCode(content=python_block, language="python", start_index=35, end_index=35 + len(python_block)),
-            MarkdownCode(content=js_block, language="javascript", start_index=150, end_index=150 + len(js_block)),
+            MarkdownCode(
+                content=python_block,
+                language="python",
+                start_index=35,
+                end_index=35 + len(python_block),
+            ),
+            MarkdownCode(
+                content=js_block,
+                language="javascript",
+                start_index=150,
+                end_index=150 + len(js_block),
+            ),
         ],
     )
 

--- a/tests/chunkers/test_table_chunker.py
+++ b/tests/chunkers/test_table_chunker.py
@@ -844,3 +844,20 @@ def test_table_chunker_html_table_malformed_no_closing_tag() -> None:
     all_content = "".join(c.text for c in chunks)
     assert "Alice" in all_content
     assert "Charlie" in all_content
+
+
+def test_table_chunker_markdown_document_no_tables_preserves_chunks() -> None:
+    """Test that TableChunker is a no-op on MarkdownDocument with no tables."""
+    doc = MarkdownDocument(
+        content="# Title\n\nSome prose text here.\n",
+        chunks=[
+            Chunk(text="Some prose text here.", start_index=10, end_index=30, token_count=4),
+        ],
+        tables=[],
+    )
+
+    chunker = TableChunker(tokenizer="row", chunk_size=3)
+    result = chunker.chunk_document(doc)
+
+    assert len(result.chunks) == 1
+    assert result.chunks[0].text == "Some prose text here."

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -563,3 +563,80 @@ class TestPipelineReturnTypes:
         result = Pipeline().fetch_from("file", dir=tmp_path).chunk_with("recursive").run()
 
         assert isinstance(result, list)
+
+
+class TestPipelineMarkdownModalities:
+    """Test pipeline with multiple chunkers for different markdown modalities."""
+
+    MARKDOWN_WITH_CODE = """
+# Machine Learning Guide
+
+Machine learning is a subset of artificial intelligence that focuses on building
+systems that learn from data. There are three main types.
+
+```python
+from sklearn.linear_model import LogisticRegression
+
+model = LogisticRegression()
+model.fit(X_train, y_train)
+accuracy = model.score(X_test, y_test)
+print(f"Accuracy: {accuracy:.2f}")
+```
+
+## Evaluation
+
+After training, you should evaluate on a held-out test set.
+
+```javascript
+function evaluate(model, testData) {
+    const predictions = model.predict(testData.features);
+    return accuracy(predictions, testData.labels);
+}
+```
+
+More text after the code blocks to ensure prose chunking works properly.
+"""
+
+    def test_markdown_with_recursive_and_code_chunkers(self) -> None:
+        """Test pipeline with markdown chef, recursive chunker for prose, and code chunker for code blocks."""
+        from chonkie.types.markdown import MarkdownDocument
+
+        doc = (
+            Pipeline()
+            .process_with("markdown")
+            .chunk_with("recursive", tokenizer="word", chunk_size=512)
+            .chunk_with("code", chunk_size=512)
+            .run(texts=self.MARKDOWN_WITH_CODE)
+        )
+
+        assert isinstance(doc, MarkdownDocument)
+        assert len(doc.chunks) > 0
+        # Should have chunks from both prose and code
+        assert len(doc.code) > 0
+
+    def test_markdown_all_modalities(self) -> None:
+        """Test pipeline with all three modality chunkers."""
+        from chonkie.types.markdown import MarkdownDocument
+
+        md_with_table = self.MARKDOWN_WITH_CODE + """
+| Metric | Value |
+|--------|-------|
+| Accuracy | 0.95 |
+| Precision | 0.93 |
+| Recall | 0.91 |
+"""
+
+        doc = (
+            Pipeline()
+            .process_with("markdown")
+            .chunk_with("recursive", tokenizer="word", chunk_size=512)
+            .chunk_with("code", chunk_size=512)
+            .chunk_with("table")
+            .refine_with("overlap", tokenizer="word", context_size=16)
+            .run(texts=md_with_table)
+        )
+
+        assert isinstance(doc, MarkdownDocument)
+        assert len(doc.chunks) > 0
+        assert len(doc.code) > 0
+        assert len(doc.tables) > 0

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -618,13 +618,16 @@ More text after the code blocks to ensure prose chunking works properly.
         """Test pipeline with all three modality chunkers."""
         from chonkie.types.markdown import MarkdownDocument
 
-        md_with_table = self.MARKDOWN_WITH_CODE + """
+        md_with_table = (
+            self.MARKDOWN_WITH_CODE
+            + """
 | Metric | Value |
 |--------|-------|
 | Accuracy | 0.95 |
 | Precision | 0.93 |
 | Recall | 0.91 |
 """
+        )
 
         doc = (
             Pipeline()


### PR DESCRIPTION
## Summary

- **CodeChunker** now has a `chunk_document` override that detects `MarkdownDocument` and chunks each `.code` block independently, with index offsetting and graceful fallback on parse errors (unsupported languages → single whole-block chunk)
- **TableChunker** bug fix: a `MarkdownDocument` with no tables previously fell to the `else` branch and overwrote all existing chunks from prior pipeline steps. Now returns the document untouched.

Together these enable multi-modality markdown pipelines where each chunker handles its own modality:

```python
doc = (Pipeline()
    .process_with("markdown")
    .chunk_with("recursive", tokenizer="word", chunk_size=512)  # prose
    .chunk_with("code", chunk_size=512)                          # code blocks
    .chunk_with("table")                                         # tables
    .refine_with("overlap", tokenizer="word", context_size=32)
    .run(texts=text))
```

No pipeline changes needed — the pipeline already supports multiple chunk steps, and each chunker self-selects its modality via `isinstance(document, MarkdownDocument)`.

## Test plan

- [x] CodeChunker: markdown doc with code blocks (python + javascript)
- [x] CodeChunker: empty code blocks skipped
- [x] CodeChunker: no code blocks → no-op (preserves existing chunks)
- [x] CodeChunker: plain Document fallback (non-markdown)
- [x] TableChunker: no tables → no-op (preserves existing chunks)
- [x] Pipeline: recursive + code chunkers on markdown
- [x] Pipeline: recursive + code + table + overlap refinery on markdown
- [x] All 100 existing tests pass (code chunker + table chunker + pipeline)
- [x] Local testing on real files (CONTRIBUTING.md, BENCHMARKS.md)