### PR TITLE
fix: Make pandas import lazy in table_converter to avoid ImportError

### DIFF
--- a/src/chonkie/utils/table_converter.py
+++ b/src/chonkie/utils/table_converter.py
@@ -3,11 +3,16 @@
 import math
 from io import StringIO
 
-import pandas as pd
-
 
 def _read_markdown_table(table_content: str):
     """Read markdown table into DataFrame."""
+    try:
+        import pandas as pd
+    except ImportError as e:
+        raise ImportError(
+            "Pandas is required to use the table converter. Please install it with `pip install chonkie[table]`.",
+        ) from e
+
     lines = [line.strip("|").strip() for line in table_content.split("\n") if line.strip()]
     if len(lines) < 2:
         return pd.DataFrame()
@@ -21,6 +26,13 @@ def _read_markdown_table(table_content: str):
 
 def _read_html_table(table_content: str):
     """Read HTML table into DataFrame."""
+    try:
+        import pandas as pd
+    except ImportError as e:
+        raise ImportError(
+            "Pandas is required to use the table converter. Please install it with `pip install chonkie[table]`.",
+        ) from e
+
     try:
         tables = pd.read_html(StringIO(table_content))
         if not tables:


### PR DESCRIPTION
Hi! There's a bug in the latest version of Chonkie:`import chonkie` fails with `ModuleNotFoundError: No module named 'pandas'` when installed without the [table] extra, because utils/table_converter.py imports pandas unconditionally at module level, and utils/__init__.py → __init__.py import from it on startup. This causes any environment that doesn't have pandas installed to fail with the latest Chonkie version.


## Reproducible example:
pip install "chonkie[code]==1.6.3"
python -c "import chonkie"
This gives `ModuleNotFoundError: No module named 'pandas'`

## Fix:
Move `import pandas as pd` inside the two functions that use it, behind a try/except ImportError with a helpful message.