### PR TITLE
Support Gemini embedding dimensions in Catsu wrappers

### DIFF
--- a/src/chonkie/embeddings/catsu.py
+++ b/src/chonkie/embeddings/catsu.py
@@ -8,7 +8,7 @@ Nomic, Cloudflare, MixedBread, DeepInfra, TogetherAI.
 """
 
 import importlib.util as importutil
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, cast
 
 import numpy as np
 
@@ -69,7 +69,7 @@ class CatsuEmbeddings(BaseEmbeddings):
         timeout: int = 30,
         verbose: bool = False,
         batch_size: int = 128,
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ):
         """Initialize Catsu embeddings adapter.
 
@@ -95,8 +95,8 @@ class CatsuEmbeddings(BaseEmbeddings):
         self.provider = provider
         self._batch_size = batch_size
         self._verbose = verbose
-        self._embed_kwargs = kwargs.copy()
-        self._configured_dimension: Optional[int] = self._embed_kwargs.get("dimensions")
+        self._embed_kwargs: Dict[str, Any] = kwargs.copy()
+        self._configured_dimension = cast(Optional[int], self._embed_kwargs.get("dimensions"))
 
         # Initialize Catsu client
         try:

--- a/src/chonkie/embeddings/catsu.py
+++ b/src/chonkie/embeddings/catsu.py
@@ -95,7 +95,9 @@ class CatsuEmbeddings(BaseEmbeddings):
         self.provider = provider
         self._batch_size = batch_size
         self._verbose = verbose
-        self._embed_kwargs: Dict[str, Any] = kwargs.copy()
+        self._embed_kwargs: Dict[str, Any] = {
+            key: value for key, value in kwargs.items() if value is not None
+        }
         self._configured_dimension = cast(Optional[int], self._embed_kwargs.get("dimensions"))
 
         # Initialize Catsu client

--- a/src/chonkie/embeddings/catsu.py
+++ b/src/chonkie/embeddings/catsu.py
@@ -95,6 +95,8 @@ class CatsuEmbeddings(BaseEmbeddings):
         self.provider = provider
         self._batch_size = batch_size
         self._verbose = verbose
+        self._embed_kwargs = kwargs.copy()
+        self._configured_dimension: Optional[int] = self._embed_kwargs.get("dimensions")
 
         # Initialize Catsu client
         try:
@@ -112,7 +114,7 @@ class CatsuEmbeddings(BaseEmbeddings):
         )
 
         # Cache for model metadata
-        self._dimension: Optional[int] = None
+        self._dimension: Optional[int] = self._configured_dimension
         self._model_info: Optional[Any] = None
 
         # Validate model exists and is supported
@@ -131,7 +133,8 @@ class CatsuEmbeddings(BaseEmbeddings):
             for model_info in models:
                 if getattr(model_info, "name", None) == self.model:
                     self._model_info = model_info
-                    self._dimension = getattr(model_info, "dimensions", None)
+                    if self._configured_dimension is None:
+                        self._dimension = getattr(model_info, "dimensions", None)
                     break
 
             if self._model_info is None and self._verbose:
@@ -160,6 +163,7 @@ class CatsuEmbeddings(BaseEmbeddings):
             model=self.model,
             input=text,
             provider=self.provider,
+            **self._embed_kwargs,
         )
 
         # Catsu returns List[List[float]], we need first embedding as 1D array
@@ -196,6 +200,7 @@ class CatsuEmbeddings(BaseEmbeddings):
                     model=self.model,
                     input=batch,
                     provider=self.provider,
+                    **self._embed_kwargs,
                 )
 
                 # Convert to list of 1D numpy arrays
@@ -235,6 +240,7 @@ class CatsuEmbeddings(BaseEmbeddings):
             model=self.model,
             input=text,
             provider=self.provider,
+            **self._embed_kwargs,
         )
         return response.to_numpy()[0]
 
@@ -261,6 +267,7 @@ class CatsuEmbeddings(BaseEmbeddings):
                 model=self.model,
                 input=batch,
                 provider=self.provider,
+                **self._embed_kwargs,
             )
             arr = response.to_numpy()
             all_embeddings.extend([arr[j] for j in range(len(batch))])

--- a/src/chonkie/embeddings/catsu.py
+++ b/src/chonkie/embeddings/catsu.py
@@ -8,7 +8,7 @@ Nomic, Cloudflare, MixedBread, DeepInfra, TogetherAI.
 """
 
 import importlib.util as importutil
-from typing import Any, Dict, List, Optional, cast
+from typing import Any, Dict, List, Optional
 
 import numpy as np
 
@@ -41,6 +41,7 @@ class CatsuEmbeddings(BaseEmbeddings):
         timeout: Request timeout in seconds (default: 30)
         verbose: Enable verbose logging (default: False)
         batch_size: Maximum number of texts to embed in one API call (default: 128)
+        dimensions: Optional output dimensionality to request from the provider
         **kwargs: Additional keyword arguments to pass to the Catsu client
 
     Examples:
@@ -69,6 +70,7 @@ class CatsuEmbeddings(BaseEmbeddings):
         timeout: int = 30,
         verbose: bool = False,
         batch_size: int = 128,
+        dimensions: Optional[int] = None,
         **kwargs: Any,
     ):
         """Initialize Catsu embeddings adapter.
@@ -81,6 +83,7 @@ class CatsuEmbeddings(BaseEmbeddings):
             timeout: Request timeout in seconds
             verbose: Enable verbose logging
             batch_size: Maximum number of texts to embed in one API call
+            dimensions: Optional output dimensionality to request from the provider
             **kwargs: Additional keyword arguments
 
         Raises:
@@ -95,17 +98,16 @@ class CatsuEmbeddings(BaseEmbeddings):
         self.provider = provider
         self._batch_size = batch_size
         self._verbose = verbose
-        reserved_embed_kwargs = {"input"}
-        conflicting_kwargs = reserved_embed_kwargs.intersection(kwargs)
-        if conflicting_kwargs:
-            conflict_list = ", ".join(sorted(conflicting_kwargs))
+        if dimensions is not None and (type(dimensions) is not int or dimensions <= 0):
+            raise ValueError("`dimensions` must be a positive integer")
+        self._dimension: Optional[int] = dimensions
+        if "input" in kwargs:
             raise ValueError(
-                f"Reserved embedding kwargs are not allowed: {conflict_list}",
+                "Reserved embedding kwargs are not allowed: input",
             )
         self._embed_kwargs: Dict[str, Any] = {
             key: value for key, value in kwargs.items() if value is not None
         }
-        self._configured_dimension = cast(Optional[int], self._embed_kwargs.get("dimensions"))
 
         # Initialize Catsu client
         try:
@@ -123,7 +125,6 @@ class CatsuEmbeddings(BaseEmbeddings):
         )
 
         # Cache for model metadata
-        self._dimension: Optional[int] = self._configured_dimension
         self._model_info: Optional[Any] = None
 
         # Validate model exists and is supported
@@ -142,7 +143,7 @@ class CatsuEmbeddings(BaseEmbeddings):
             for model_info in models:
                 if getattr(model_info, "name", None) == self.model:
                     self._model_info = model_info
-                    if self._configured_dimension is None:
+                    if self._dimension is None:
                         self._dimension = getattr(model_info, "dimensions", None)
                     break
 
@@ -172,6 +173,7 @@ class CatsuEmbeddings(BaseEmbeddings):
             model=self.model,
             input=text,
             provider=self.provider,
+            dimensions=self._dimension,
             **self._embed_kwargs,
         )
 
@@ -209,6 +211,7 @@ class CatsuEmbeddings(BaseEmbeddings):
                     model=self.model,
                     input=batch,
                     provider=self.provider,
+                    dimensions=self._dimension,
                     **self._embed_kwargs,
                 )
 
@@ -249,6 +252,7 @@ class CatsuEmbeddings(BaseEmbeddings):
             model=self.model,
             input=text,
             provider=self.provider,
+            dimensions=self._dimension,
             **self._embed_kwargs,
         )
         return response.to_numpy()[0]
@@ -276,6 +280,7 @@ class CatsuEmbeddings(BaseEmbeddings):
                 model=self.model,
                 input=batch,
                 provider=self.provider,
+                dimensions=self._dimension,
                 **self._embed_kwargs,
             )
             arr = response.to_numpy()

--- a/src/chonkie/embeddings/catsu.py
+++ b/src/chonkie/embeddings/catsu.py
@@ -95,6 +95,13 @@ class CatsuEmbeddings(BaseEmbeddings):
         self.provider = provider
         self._batch_size = batch_size
         self._verbose = verbose
+        reserved_embed_kwargs = {"input"}
+        conflicting_kwargs = reserved_embed_kwargs.intersection(kwargs)
+        if conflicting_kwargs:
+            conflict_list = ", ".join(sorted(conflicting_kwargs))
+            raise ValueError(
+                f"Reserved embedding kwargs are not allowed: {conflict_list}",
+            )
         self._embed_kwargs: Dict[str, Any] = {
             key: value for key, value in kwargs.items() if value is not None
         }

--- a/src/chonkie/embeddings/gemini.py
+++ b/src/chonkie/embeddings/gemini.py
@@ -23,6 +23,7 @@ class GeminiEmbeddings(BaseEmbeddings):
     Args:
         model: Gemini embedding model name (default: "gemini-embedding-001").
         api_key: Gemini API key (or set GEMINI_API_KEY env var).
+        dimensions: Optional output dimensionality to request from Gemini.
         task_type: Ignored; kept for backward compatibility.
         max_retries: Maximum retry attempts (default: 3).
         batch_size: Number of texts per API call (default: 100).
@@ -42,6 +43,7 @@ class GeminiEmbeddings(BaseEmbeddings):
         self,
         model: str = DEFAULT_MODEL,
         api_key: Optional[str] = None,
+        dimensions: Optional[int] = None,
         task_type: str = "SEMANTIC_SIMILARITY",
         max_retries: int = 3,
         batch_size: int = 100,
@@ -52,6 +54,7 @@ class GeminiEmbeddings(BaseEmbeddings):
         Args:
             model: Gemini embedding model name.
             api_key: Gemini API key (falls back to GEMINI_API_KEY env var).
+            dimensions: Optional output dimensionality for Gemini embeddings.
             task_type: Ignored; kept for backward compatibility.
             max_retries: Maximum retry attempts.
             batch_size: Number of texts per API call.
@@ -83,6 +86,7 @@ class GeminiEmbeddings(BaseEmbeddings):
             )
 
         self.model = model if model else self.DEFAULT_MODEL
+        self.dimensions = dimensions
         self.task_type = task_type
         api_key = api_key or os.getenv("GEMINI_API_KEY")
         api_keys = {"gemini": api_key} if api_key else None
@@ -93,6 +97,7 @@ class GeminiEmbeddings(BaseEmbeddings):
             api_keys=api_keys,
             max_retries=max_retries,
             batch_size=batch_size,
+            dimensions=dimensions,
         )
 
     def embed(self, text: str) -> np.ndarray:

--- a/src/chonkie/embeddings/gemini.py
+++ b/src/chonkie/embeddings/gemini.py
@@ -86,6 +86,8 @@ class GeminiEmbeddings(BaseEmbeddings):
             )
 
         self.model = model if model else self.DEFAULT_MODEL
+        if dimensions is not None and (not isinstance(dimensions, int) or dimensions <= 0):
+            raise ValueError("`dimensions` must be a positive integer")
         self.dimensions = dimensions
         self.task_type = task_type
         api_key = api_key or os.getenv("GEMINI_API_KEY")

--- a/src/chonkie/embeddings/gemini.py
+++ b/src/chonkie/embeddings/gemini.py
@@ -86,7 +86,7 @@ class GeminiEmbeddings(BaseEmbeddings):
             )
 
         self.model = model if model else self.DEFAULT_MODEL
-        if dimensions is not None and (not isinstance(dimensions, int) or dimensions <= 0):
+        if dimensions is not None and (type(dimensions) is not int or dimensions <= 0):
             raise ValueError("`dimensions` must be a positive integer")
         self.dimensions = dimensions
         self.task_type = task_type

--- a/tests/embeddings/test_catsu_embeddings.py
+++ b/tests/embeddings/test_catsu_embeddings.py
@@ -106,6 +106,41 @@ def test_embed_single_text(embedding_model: CatsuEmbeddings, sample_text: str) -
     not CATSU_AVAILABLE,
     reason="Skipping test because Catsu is not installed",
 )
+def test_embed_single_text_forwards_dimensions(mock_catsu_client, sample_text: str) -> None:
+    """Test that custom dimensions are forwarded to Catsu embed calls."""
+    with patch("catsu.Client", return_value=mock_catsu_client):
+        embedding_model = CatsuEmbeddings(
+            model="gemini-embedding-001",
+            provider="gemini",
+            dimensions=768,
+        )
+
+    embedding_model.embed(sample_text)
+
+    call_kwargs = embedding_model.client.embed.call_args[1]
+    assert call_kwargs["dimensions"] == 768
+
+
+@pytest.mark.skipif(
+    not CATSU_AVAILABLE,
+    reason="Skipping test because Catsu is not installed",
+)
+def test_dimension_property_prefers_configured_dimensions(mock_catsu_client) -> None:
+    """Test that configured dimensions override catalog dimensions."""
+    with patch("catsu.Client", return_value=mock_catsu_client):
+        embeddings = CatsuEmbeddings(
+            model="gemini-embedding-001",
+            provider="gemini",
+            dimensions=768,
+        )
+
+    assert embeddings.dimension == 768
+
+
+@pytest.mark.skipif(
+    not CATSU_AVAILABLE,
+    reason="Skipping test because Catsu is not installed",
+)
 def test_embed_batch_texts(embedding_model: CatsuEmbeddings, sample_texts: List[str]) -> None:
     """Test that CatsuEmbeddings correctly embeds a batch of texts."""
     # Mock the client to return correct number of embeddings

--- a/tests/embeddings/test_catsu_embeddings.py
+++ b/tests/embeddings/test_catsu_embeddings.py
@@ -2,7 +2,7 @@
 
 import os
 from typing import List
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import numpy as np
 import pytest
@@ -125,6 +125,28 @@ def test_embed_single_text_forwards_dimensions(mock_catsu_client, sample_text: s
     not CATSU_AVAILABLE,
     reason="Skipping test because Catsu is not installed",
 )
+@pytest.mark.asyncio
+async def test_aembed_forwards_dimensions(mock_catsu_client, sample_text: str) -> None:
+    """Test that custom dimensions are forwarded to async Catsu embed calls."""
+    mock_catsu_client.aembed = AsyncMock(return_value=mock_catsu_client.embed.return_value)
+
+    with patch("catsu.Client", return_value=mock_catsu_client):
+        embedding_model = CatsuEmbeddings(
+            model="gemini-embedding-001",
+            provider="gemini",
+            dimensions=768,
+        )
+
+    await embedding_model.aembed(sample_text)
+
+    call_kwargs = embedding_model.client.aembed.call_args[1]
+    assert call_kwargs["dimensions"] == 768
+
+
+@pytest.mark.skipif(
+    not CATSU_AVAILABLE,
+    reason="Skipping test because Catsu is not installed",
+)
 def test_dimension_property_prefers_configured_dimensions(mock_catsu_client) -> None:
     """Test that configured dimensions override catalog dimensions."""
     with patch("catsu.Client", return_value=mock_catsu_client):
@@ -135,6 +157,28 @@ def test_dimension_property_prefers_configured_dimensions(mock_catsu_client) -> 
         )
 
     assert embeddings.dimension == 768
+
+
+@pytest.mark.skipif(
+    not CATSU_AVAILABLE,
+    reason="Skipping test because Catsu is not installed",
+)
+@pytest.mark.asyncio
+async def test_aembed_batch_forwards_dimensions(mock_catsu_client, sample_text: str) -> None:
+    """Test that custom dimensions are forwarded to async Catsu batch embed calls."""
+    mock_catsu_client.aembed = AsyncMock(return_value=mock_catsu_client.embed.return_value)
+
+    with patch("catsu.Client", return_value=mock_catsu_client):
+        embedding_model = CatsuEmbeddings(
+            model="gemini-embedding-001",
+            provider="gemini",
+            dimensions=768,
+        )
+
+    await embedding_model.aembed_batch([sample_text])
+
+    call_kwargs = embedding_model.client.aembed.call_args[1]
+    assert call_kwargs["dimensions"] == 768
 
 
 @pytest.mark.skipif(

--- a/tests/embeddings/test_catsu_embeddings.py
+++ b/tests/embeddings/test_catsu_embeddings.py
@@ -163,6 +163,21 @@ def test_dimension_property_prefers_configured_dimensions(mock_catsu_client) -> 
     not CATSU_AVAILABLE,
     reason="Skipping test because Catsu is not installed",
 )
+def test_initialization_rejects_reserved_input_kwarg(mock_catsu_client) -> None:
+    """Test that reserved embed input kwargs are rejected during initialization."""
+    with patch("catsu.Client", return_value=mock_catsu_client):
+        with pytest.raises(ValueError, match="input"):
+            CatsuEmbeddings(
+                model="gemini-embedding-001",
+                provider="gemini",
+                input="conflict",
+            )
+
+
+@pytest.mark.skipif(
+    not CATSU_AVAILABLE,
+    reason="Skipping test because Catsu is not installed",
+)
 @pytest.mark.asyncio
 async def test_aembed_batch_forwards_dimensions(mock_catsu_client, sample_text: str) -> None:
     """Test that custom dimensions are forwarded to async Catsu batch embed calls."""

--- a/tests/embeddings/test_catsu_embeddings.py
+++ b/tests/embeddings/test_catsu_embeddings.py
@@ -1,5 +1,6 @@
 """Test suite for CatsuEmbeddings."""
 
+import inspect
 import os
 from typing import List
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -93,6 +94,30 @@ def test_initialization_with_config_params(mock_catsu_client) -> None:
         assert embeddings._batch_size == 64
 
 
+def test_initialization_exposes_dimensions_parameter() -> None:
+    """Test that CatsuEmbeddings exposes dimensions as a first-class parameter."""
+    signature = inspect.signature(CatsuEmbeddings)
+    dimensions = signature.parameters["dimensions"]
+
+    assert dimensions.default is None
+
+
+@pytest.mark.skipif(
+    not CATSU_AVAILABLE,
+    reason="Skipping test because Catsu is not installed",
+)
+@pytest.mark.parametrize("dimensions", [0, -1, "768", True])
+def test_initialization_rejects_invalid_dimensions(mock_catsu_client, dimensions) -> None:
+    """Test that invalid custom dimensions fail fast."""
+    with patch("catsu.Client", return_value=mock_catsu_client):
+        with pytest.raises(ValueError, match="positive integer"):
+            CatsuEmbeddings(
+                model="gemini-embedding-001",
+                provider="gemini",
+                dimensions=dimensions,
+            )
+
+
 def test_embed_single_text(embedding_model: CatsuEmbeddings, sample_text: str) -> None:
     """Test that CatsuEmbeddings correctly embeds a single text."""
     embedding = embedding_model.embed(sample_text)
@@ -157,6 +182,25 @@ def test_dimension_property_prefers_configured_dimensions(mock_catsu_client) -> 
         )
 
     assert embeddings.dimension == 768
+
+
+@pytest.mark.skipif(
+    not CATSU_AVAILABLE,
+    reason="Skipping test because Catsu is not installed",
+)
+def test_embed_batch_forwards_dimensions(mock_catsu_client, sample_text: str) -> None:
+    """Test that custom dimensions are forwarded to Catsu batch embed calls."""
+    with patch("catsu.Client", return_value=mock_catsu_client):
+        embedding_model = CatsuEmbeddings(
+            model="gemini-embedding-001",
+            provider="gemini",
+            dimensions=768,
+        )
+
+    embedding_model.embed_batch([sample_text])
+
+    call_kwargs = embedding_model.client.embed.call_args[1]
+    assert call_kwargs["dimensions"] == 768
 
 
 @pytest.mark.skipif(

--- a/tests/embeddings/test_gemini_embeddings.py
+++ b/tests/embeddings/test_gemini_embeddings.py
@@ -82,6 +82,14 @@ def test_initialization_with_custom_model(mock_catsu_client) -> None:
         assert embeddings.model == "text-embedding-004"
 
 
+def test_initialization_with_dimensions(mock_catsu_client) -> None:
+    """Test initialization with custom output dimensions."""
+    with patch("catsu.Client", return_value=mock_catsu_client):
+        embeddings = GeminiEmbeddings(api_key="test-key", dimensions=768)
+        assert embeddings.dimensions == 768
+        assert embeddings.dimension == 768
+
+
 def test_default_model() -> None:
     """Test that GeminiEmbeddings has the correct default model."""
     assert GeminiEmbeddings.DEFAULT_MODEL == "gemini-embedding-001"
@@ -98,6 +106,17 @@ def test_embed_single_text(
     result = embedding_model.embed(sample_text)
     assert isinstance(result, np.ndarray)
     assert result.ndim == 1
+
+
+def test_embed_forwards_dimensions(mock_catsu_client) -> None:
+    """Test that Gemini dimensions are forwarded to Catsu embed calls."""
+    with patch("catsu.Client", return_value=mock_catsu_client):
+        embeddings = GeminiEmbeddings(api_key="test-key", dimensions=768)
+
+    embeddings.embed("hello world")
+
+    call_kwargs = embeddings._catsu.client.embed.call_args[1]
+    assert call_kwargs["dimensions"] == 768
 
 
 def test_embed_batch_texts(

--- a/tests/embeddings/test_gemini_embeddings.py
+++ b/tests/embeddings/test_gemini_embeddings.py
@@ -119,6 +119,25 @@ def test_embed_forwards_dimensions(mock_catsu_client) -> None:
     assert call_kwargs["dimensions"] == 768
 
 
+def test_embed_omits_dimensions_when_unconfigured(mock_catsu_client) -> None:
+    """Test that default Gemini embed calls omit dimensions."""
+    with patch("catsu.Client", return_value=mock_catsu_client):
+        embeddings = GeminiEmbeddings(api_key="test-key")
+
+    embeddings.embed("hello world")
+
+    call_kwargs = embeddings._catsu.client.embed.call_args[1]
+    assert "dimensions" not in call_kwargs
+
+
+@pytest.mark.parametrize("dimensions", [0, -1, "768"])
+def test_initialization_rejects_invalid_dimensions(mock_catsu_client, dimensions) -> None:
+    """Test that invalid custom dimensions fail fast."""
+    with patch("catsu.Client", return_value=mock_catsu_client):
+        with pytest.raises(ValueError, match="positive integer"):
+            GeminiEmbeddings(api_key="test-key", dimensions=dimensions)
+
+
 def test_embed_batch_texts(
     embedding_model: GeminiEmbeddings, sample_texts: list, mock_catsu_client
 ) -> None:

--- a/tests/embeddings/test_gemini_embeddings.py
+++ b/tests/embeddings/test_gemini_embeddings.py
@@ -119,15 +119,15 @@ def test_embed_forwards_dimensions(mock_catsu_client) -> None:
     assert call_kwargs["dimensions"] == 768
 
 
-def test_embed_omits_dimensions_when_unconfigured(mock_catsu_client) -> None:
-    """Test that default Gemini embed calls omit dimensions."""
+def test_embed_uses_default_dimensions_when_unconfigured(mock_catsu_client) -> None:
+    """Test that default Gemini embed calls use the model dimensions."""
     with patch("catsu.Client", return_value=mock_catsu_client):
         embeddings = GeminiEmbeddings(api_key="test-key")
 
     embeddings.embed("hello world")
 
     call_kwargs = embeddings._catsu.client.embed.call_args[1]
-    assert "dimensions" not in call_kwargs
+    assert call_kwargs["dimensions"] == 3072
 
 
 @pytest.mark.parametrize("dimensions", [0, -1, "768", True])

--- a/tests/embeddings/test_gemini_embeddings.py
+++ b/tests/embeddings/test_gemini_embeddings.py
@@ -130,7 +130,7 @@ def test_embed_omits_dimensions_when_unconfigured(mock_catsu_client) -> None:
     assert "dimensions" not in call_kwargs
 
 
-@pytest.mark.parametrize("dimensions", [0, -1, "768"])
+@pytest.mark.parametrize("dimensions", [0, -1, "768", True])
 def test_initialization_rejects_invalid_dimensions(mock_catsu_client, dimensions) -> None:
     """Test that invalid custom dimensions fail fast."""
     with patch("catsu.Client", return_value=mock_catsu_client):


### PR DESCRIPTION
Forward Gemini `dimensions` through `CatsuEmbeddings` and add test coverage.

This fixes the case where `GeminiEmbeddings(dimensions=...)` was accepted by the wrapper but not actually sent to the underlying embed call.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional dimensions control for Gemini embeddings so callers can request a specific embedding dimensionality.
  * Embedding adapter accepts and preserves arbitrary non-null embedding options, forwarding them through all embedding calls.

* **Tests**
  * Added tests confirming dimensions are validated, stored, and correctly forwarded for synchronous and asynchronous embedding requests, including batch calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->