### PR TITLE
[codex] Support Voyage contextual embeddings in pipelines

### DIFF
--- a/docs/oss/embeddings/overview.mdx
+++ b/docs/oss/embeddings/overview.mdx
@@ -85,7 +85,7 @@ Embeddings handlers require additional dependencies. See the [Installation Guide
     icon="brain-circuit"
     href="/oss/embeddings/voyageai-embeddings"
   >
-    Embed text using VoyageAI embeddings (requires `voyageai`).
+    Embed text using VoyageAI embeddings (requires `catsu`).
   </Card>
 </CardGroup>
 

--- a/docs/oss/embeddings/voyageai-embeddings.mdx
+++ b/docs/oss/embeddings/voyageai-embeddings.mdx
@@ -6,11 +6,11 @@ icon: brain-circuit
 iconType: solid
 ---
 
-Embeddings are handled by the `VoyageAIEmbeddings` class, which is a wrapper around the VoyageAI API.
+Embeddings are handled by the `VoyageAIEmbeddings` class, which is a wrapper around Catsu's VoyageAI provider.
 
 ## Installation
 
-Embeddings require the `voyageai`, `numpy`, and `tokenizers` libraries. See the [Installation Guide](/oss/installation) for more information.
+Embeddings require the `catsu`, `numpy`, and `tokenizers` libraries. See the [Installation Guide](/oss/installation) for more information.
 
 ```bash
 pip install "chonkie[voyageai]"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,7 +113,7 @@ azure-openai = [
 ]
 groq = ["pydantic>=2.0.0", "groq>=0.4.0"]
 cerebras = ["pydantic>=2.0.0", "cerebras-cloud-sdk>=1.0.0"]
-voyageai = ["tokenizers>=0.16.0", "voyageai>=0.3.2"]
+voyageai = ["tokenizers>=0.16.0", "catsu>=0.0.1"]
 cohere = ["tokenizers>=0.16.0", "cohere>=5.13.0"]
 jina = ["tokenizers>=0.16.0"]
 catsu = ["catsu>=0.0.1"]

--- a/src/chonkie/embeddings/catsu.py
+++ b/src/chonkie/embeddings/catsu.py
@@ -7,8 +7,9 @@ Supported providers: VoyageAI, OpenAI, Cohere, Gemini, Jina AI, Mistral,
 Nomic, Cloudflare, MixedBread, DeepInfra, TogetherAI.
 """
 
+import asyncio
 import importlib.util as importutil
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Literal, Optional, Sequence
 
 import numpy as np
 
@@ -41,6 +42,7 @@ class CatsuEmbeddings(BaseEmbeddings):
         timeout: Request timeout in seconds (default: 30)
         verbose: Enable verbose logging (default: False)
         batch_size: Maximum number of texts to embed in one API call (default: 128)
+        dimensions: Optional output dimension for models that support it
         **kwargs: Additional keyword arguments to pass to the Catsu client
 
     Examples:
@@ -60,6 +62,8 @@ class CatsuEmbeddings(BaseEmbeddings):
 
     """
 
+    CONTEXTUALIZED_MODELS = {"voyage-context-3"}
+
     def __init__(
         self,
         model: str,
@@ -69,6 +73,7 @@ class CatsuEmbeddings(BaseEmbeddings):
         timeout: int = 30,
         verbose: bool = False,
         batch_size: int = 128,
+        dimensions: Optional[int] = None,
         **kwargs: Dict[str, Any],
     ):
         """Initialize Catsu embeddings adapter.
@@ -81,6 +86,7 @@ class CatsuEmbeddings(BaseEmbeddings):
             timeout: Request timeout in seconds
             verbose: Enable verbose logging
             batch_size: Maximum number of texts to embed in one API call
+            dimensions: Optional output dimension for models that support it
             **kwargs: Additional keyword arguments
 
         Raises:
@@ -95,6 +101,8 @@ class CatsuEmbeddings(BaseEmbeddings):
         self.provider = provider
         self._batch_size = batch_size
         self._verbose = verbose
+        self._is_contextualized = model in self.CONTEXTUALIZED_MODELS
+        self._dimensions = dimensions
 
         # Initialize Catsu client
         try:
@@ -123,6 +131,9 @@ class CatsuEmbeddings(BaseEmbeddings):
                 f"Could not load model info for {model}: {e}. Will attempt to use model anyway.",
                 exc_info=True,
             )
+
+        if self._dimensions is not None:
+            self._dimension = self._dimensions
 
     def _load_model_info(self) -> None:
         """Load model metadata from Catsu catalog."""
@@ -156,15 +167,48 @@ class CatsuEmbeddings(BaseEmbeddings):
             Various Catsu exceptions for API errors, auth failures, etc.
 
         """
+        if self._is_contextualized:
+            return self._contextualized_embed([[text]], input_type="query")[0]
+
         response = self.client.embed(
             model=self.model,
             input=text,
             provider=self.provider,
+            dimensions=self._dimensions,
         )
 
         # Catsu returns List[List[float]], we need first embedding as 1D array
         embeddings_array = response.to_numpy()
         return embeddings_array[0]
+
+    def _contextualized_embed(
+        self,
+        inputs: Sequence[Sequence[str]],
+        input_type: Literal["query", "document"],
+    ) -> List[np.ndarray]:
+        """Embed grouped inputs with a contextualized embedding endpoint."""
+        groups = [list(group) for group in inputs if group]
+        if not groups:
+            return []
+
+        if not hasattr(self.client, "contextualized_embed"):
+            raise RuntimeError(
+                "The installed catsu package does not support contextualized embeddings. "
+                "Install a catsu version with `contextualized_embed` support.",
+            )
+
+        response = self.client.contextualized_embed(
+            model=self.model,
+            inputs=groups,
+            provider=self.provider,
+            input_type=input_type,
+            dimensions=self._dimensions,
+        )
+        return [
+            np.asarray(embedding, dtype=np.float32)
+            for group in response.embeddings
+            for embedding in group
+        ]
 
     def embed_batch(self, texts: List[str]) -> List[np.ndarray]:
         """Embed multiple texts using batched API calls.
@@ -184,6 +228,8 @@ class CatsuEmbeddings(BaseEmbeddings):
         """
         if not texts:
             return []
+        if self._is_contextualized:
+            return self.embed_documents([texts])
 
         all_embeddings = []
 
@@ -196,6 +242,7 @@ class CatsuEmbeddings(BaseEmbeddings):
                     model=self.model,
                     input=batch,
                     provider=self.provider,
+                    dimensions=self._dimensions,
                 )
 
                 # Convert to list of 1D numpy arrays
@@ -218,6 +265,12 @@ class CatsuEmbeddings(BaseEmbeddings):
 
         return all_embeddings
 
+    def embed_documents(self, documents: Sequence[Sequence[str]]) -> List[np.ndarray]:
+        """Embed document chunk groups while preserving document boundaries."""
+        if self._is_contextualized:
+            return self._contextualized_embed(documents, input_type="document")
+        return self.embed_batch([text for document in documents for text in document])
+
     async def aembed(self, text: str) -> np.ndarray:
         """Embed a single text string asynchronously.
 
@@ -231,10 +284,14 @@ class CatsuEmbeddings(BaseEmbeddings):
             Various Catsu exceptions for API errors, auth failures, etc.
 
         """
+        if self._is_contextualized:
+            return await asyncio.to_thread(self.embed, text)
+
         response = await self.client.aembed(
             model=self.model,
             input=text,
             provider=self.provider,
+            dimensions=self._dimensions,
         )
         return response.to_numpy()[0]
 
@@ -253,6 +310,8 @@ class CatsuEmbeddings(BaseEmbeddings):
         """
         if not texts:
             return []
+        if self._is_contextualized:
+            return await asyncio.to_thread(self.embed_batch, texts)
 
         all_embeddings = []
         for i in range(0, len(texts), self._batch_size):
@@ -261,10 +320,15 @@ class CatsuEmbeddings(BaseEmbeddings):
                 model=self.model,
                 input=batch,
                 provider=self.provider,
+                dimensions=self._dimensions,
             )
             arr = response.to_numpy()
             all_embeddings.extend([arr[j] for j in range(len(batch))])
         return all_embeddings
+
+    async def aembed_documents(self, documents: Sequence[Sequence[str]]) -> List[np.ndarray]:
+        """Embed document chunk groups asynchronously."""
+        return await asyncio.to_thread(self.embed_documents, documents)
 
     @property
     def dimension(self) -> int:

--- a/src/chonkie/embeddings/registry.py
+++ b/src/chonkie/embeddings/registry.py
@@ -19,6 +19,7 @@ from .nomic import NomicEmbeddings
 from .openai import OpenAIEmbeddings
 from .sentence_transformer import SentenceTransformerEmbeddings
 from .together import TogetherEmbeddings
+from .voyageai import VoyageAIEmbeddings
 
 
 class EmbeddingsRegistry:
@@ -263,6 +264,7 @@ EmbeddingsRegistry.register_model("voyage-3-large", CatsuEmbeddings)
 EmbeddingsRegistry.register_model("voyage-3", CatsuEmbeddings)
 EmbeddingsRegistry.register_model("voyage-3-lite", CatsuEmbeddings)
 EmbeddingsRegistry.register_model("voyage-code-3", CatsuEmbeddings)
+EmbeddingsRegistry.register_model("voyage-context-3", VoyageAIEmbeddings)
 EmbeddingsRegistry.register_model("voyage-finance-2", CatsuEmbeddings)
 EmbeddingsRegistry.register_model("voyage-law-2", CatsuEmbeddings)
 EmbeddingsRegistry.register_model("voyage-code-2", CatsuEmbeddings)

--- a/src/chonkie/embeddings/voyageai.py
+++ b/src/chonkie/embeddings/voyageai.py
@@ -3,10 +3,11 @@
 Note: Consider using CatsuEmbeddings(model=..., provider="voyageai") directly.
 """
 
+import asyncio
 import importlib.util as importutil
 import os
 import warnings
-from typing import Any, Literal, Optional
+from typing import Any, Literal, Optional, Sequence
 
 import numpy as np
 
@@ -25,17 +26,19 @@ class VoyageAIEmbeddings(BaseEmbeddings):
         api_key: VoyageAI API key (falls back to VOYAGE_API_KEY or VOYAGEAI_API_KEY env var).
         max_retries: Maximum retry attempts (default: 3).
         timeout: Request timeout in seconds (default: 60).
-        output_dimension: Ignored; kept for backward compatibility.
+        output_dimension: Optional output dimension for contextual Voyage models.
         batch_size: Number of texts per API call (default: 128).
-        truncation: Ignored; kept for backward compatibility.
+        truncation: Ignored for contextual Voyage models and delegated otherwise.
 
     """
 
+    CONTEXTUALIZED_MODELS = {"voyage-context-3"}
     AVAILABLE_MODELS = {
         "voyage-3-large": ((1024, 256, 512, 2048), 32000),
         "voyage-3": ((1024,), 32000),
         "voyage-3-lite": ((512,), 32000),
         "voyage-code-3": ((1024, 256, 512, 2048), 32000),
+        "voyage-context-3": ((1024, 256, 512, 2048), 120000),
         "voyage-finance-2": ((1024,), 32000),
         "voyage-law-2": ((1024,), 16000),
         "voyage-code-2": ((1536,), 16000),
@@ -60,15 +63,53 @@ class VoyageAIEmbeddings(BaseEmbeddings):
             api_key: VoyageAI API key (falls back to VOYAGE_API_KEY or VOYAGEAI_API_KEY env var).
             max_retries: Maximum retry attempts.
             timeout: Request timeout in seconds.
-            output_dimension: Ignored; kept for backward compatibility.
+            output_dimension: Optional output dimension for contextual Voyage models.
             batch_size: Number of texts per API call (max 128).
-            truncation: Ignored; kept for backward compatibility.
+            truncation: Ignored for contextual Voyage models and delegated otherwise.
 
         Raises:
             ImportError: If the catsu package is not installed.
 
         """
         super().__init__()
+
+        self.model = model
+        self._is_contextualized = model in self.CONTEXTUALIZED_MODELS
+        api_key = api_key or os.getenv("VOYAGE_API_KEY") or os.getenv("VOYAGEAI_API_KEY")
+
+        if self._is_contextualized:
+            if importutil.find_spec("voyageai") is None:
+                raise ImportError(
+                    "The voyageai package is not available. "
+                    'Please install it via `pip install "chonkie[voyageai]"`',
+                )
+            import voyageai
+
+            allowed_dims, _ = self.AVAILABLE_MODELS[model]
+            if output_dimension is None:
+                output_dimension = allowed_dims[0]
+            elif output_dimension not in allowed_dims:
+                raise ValueError(
+                    f"Invalid output_dimension={output_dimension} for model={model}. "
+                    f"Allowed: {sorted(allowed_dims)}",
+                )
+            if truncation is not True:
+                warnings.warn(
+                    "The `truncation` parameter is not supported for contextualized "
+                    "Voyage embeddings and will be ignored.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+
+            self.output_dimension = output_dimension
+            self._dimension = output_dimension
+            self._tokenizer: Any = None
+            self._client = voyageai.Client(
+                api_key=api_key,
+                max_retries=max_retries,
+                timeout=timeout,
+            )
+            return
 
         if not self._is_available():
             raise ImportError(
@@ -89,10 +130,7 @@ class VoyageAIEmbeddings(BaseEmbeddings):
                 stacklevel=2,
             )
 
-        self.model = model
-        api_key = api_key or os.getenv("VOYAGE_API_KEY") or os.getenv("VOYAGEAI_API_KEY")
         api_keys = {"voyageai": api_key} if api_key else None
-
         self._catsu = CatsuEmbeddings(
             model=model,
             provider="voyageai",
@@ -102,29 +140,82 @@ class VoyageAIEmbeddings(BaseEmbeddings):
             batch_size=min(batch_size, 128),
         )
 
+    def _contextualized_embed(
+        self,
+        inputs: Sequence[Sequence[str]],
+        input_type: Literal["query", "document"],
+    ) -> list[np.ndarray]:
+        """Embed grouped text inputs with Voyage contextualized embeddings."""
+        groups = [list(group) for group in inputs if group]
+        if not groups:
+            return []
+
+        response = self._client.contextualized_embed(
+            inputs=groups,
+            model=self.model,
+            input_type=input_type,
+            output_dimension=self.output_dimension,
+        )
+        return [
+            np.array(embedding, dtype=np.float32)
+            for result in response.results
+            for embedding in result.embeddings
+        ]
+
     def embed(self, text: str) -> np.ndarray:
         """Embed a single text string."""
+        if self._is_contextualized:
+            return self._contextualized_embed([[text]], input_type="query")[0]
         return self._catsu.embed(text)
 
     def embed_batch(self, texts: list) -> list:
         """Embed multiple texts using batched API calls."""
+        if self._is_contextualized:
+            return self.embed_documents([texts])
         return self._catsu.embed_batch(texts)
+
+    def embed_documents(self, documents: Sequence[Sequence[str]]) -> list[np.ndarray]:
+        """Embed document chunk groups while preserving document boundaries."""
+        if self._is_contextualized:
+            return self._contextualized_embed(documents, input_type="document")
+        return self.embed_batch([text for document in documents for text in document])
 
     async def aembed(self, text: str) -> np.ndarray:
         """Embed a single text string asynchronously."""
+        if self._is_contextualized:
+            return await asyncio.to_thread(self.embed, text)
         return await self._catsu.aembed(text)
 
     async def aembed_batch(self, texts: list) -> list:
         """Embed multiple texts asynchronously using batched API calls."""
+        if self._is_contextualized:
+            return await asyncio.to_thread(self.embed_batch, texts)
         return await self._catsu.aembed_batch(texts)
+
+    async def aembed_documents(self, documents: Sequence[Sequence[str]]) -> list[np.ndarray]:
+        """Embed document chunk groups asynchronously."""
+        return await asyncio.to_thread(self.embed_documents, documents)
 
     @property
     def dimension(self) -> int:
         """Return the embedding dimension."""
+        if self._is_contextualized:
+            return self._dimension
         return self._catsu.dimension
 
     def get_tokenizer(self) -> Any:
         """Return a tokenizer object for token counting."""
+        if self._is_contextualized:
+            if self._tokenizer is None:
+                try:
+                    from tokenizers import Tokenizer
+
+                    self._tokenizer = Tokenizer.from_pretrained(f"voyageai/{self.model}")
+                except Exception as e:
+                    raise ValueError(
+                        f"Failed to initialize tokenizer for model {self.model}: {e}"
+                    ) from e
+            return self._tokenizer
         return self._catsu.get_tokenizer()
 
     @classmethod

--- a/src/chonkie/embeddings/voyageai.py
+++ b/src/chonkie/embeddings/voyageai.py
@@ -77,14 +77,13 @@ class VoyageAIEmbeddings(BaseEmbeddings):
         self._is_contextualized = model in self.CONTEXTUALIZED_MODELS
         api_key = api_key or os.getenv("VOYAGE_API_KEY") or os.getenv("VOYAGEAI_API_KEY")
 
-        if self._is_contextualized:
-            if importutil.find_spec("voyageai") is None:
-                raise ImportError(
-                    "The voyageai package is not available. "
-                    'Please install it via `pip install "chonkie[voyageai]"`',
-                )
-            import voyageai
+        if not self._is_available():
+            raise ImportError(
+                "One (or more) of the following packages is not available: catsu. "
+                'Please install it via `pip install "chonkie[catsu]"`',
+            )
 
+        if self._is_contextualized:
             allowed_dims, _ = self.AVAILABLE_MODELS[model]
             if output_dimension is None:
                 output_dimension = allowed_dims[0]
@@ -104,20 +103,7 @@ class VoyageAIEmbeddings(BaseEmbeddings):
             self.output_dimension = output_dimension
             self._dimension = output_dimension
             self._tokenizer: Any = None
-            self._client = voyageai.Client(
-                api_key=api_key,
-                max_retries=max_retries,
-                timeout=timeout,
-            )
-            return
-
-        if not self._is_available():
-            raise ImportError(
-                "One (or more) of the following packages is not available: catsu. "
-                'Please install it via `pip install "chonkie[catsu]"`',
-            )
-
-        if output_dimension is not None:
+        elif output_dimension is not None:
             warnings.warn(
                 "The `output_dimension` parameter is not supported in this version and will be ignored.",
                 DeprecationWarning,
@@ -138,6 +124,7 @@ class VoyageAIEmbeddings(BaseEmbeddings):
             max_retries=max_retries,
             timeout=round(timeout),
             batch_size=min(batch_size, 128),
+            dimensions=output_dimension if self._is_contextualized else None,
         )
 
     def _contextualized_embed(
@@ -149,18 +136,9 @@ class VoyageAIEmbeddings(BaseEmbeddings):
         groups = [list(group) for group in inputs if group]
         if not groups:
             return []
-
-        response = self._client.contextualized_embed(
-            inputs=groups,
-            model=self.model,
-            input_type=input_type,
-            output_dimension=self.output_dimension,
-        )
-        return [
-            np.array(embedding, dtype=np.float32)
-            for result in response.results
-            for embedding in result.embeddings
-        ]
+        if input_type == "query":
+            return [self._catsu.embed(text) for group in groups for text in group]
+        return self._catsu.embed_documents(groups)
 
     def embed(self, text: str) -> np.ndarray:
         """Embed a single text string."""

--- a/src/chonkie/handshakes/turbopuffer.py
+++ b/src/chonkie/handshakes/turbopuffer.py
@@ -20,6 +20,8 @@ logger = get_logger(__name__)
 class TurbopufferHandshake(BaseHandshake):
     """Turbopuffer Handshake to export Chonkie's Chunks into a Turbopuffer database."""
 
+    preserves_document_boundaries = True
+
     def __init__(
         self,
         namespace: Optional[Any] = None,  # Will be tpuf.Namespace at runtime

--- a/src/chonkie/handshakes/turbopuffer.py
+++ b/src/chonkie/handshakes/turbopuffer.py
@@ -8,7 +8,7 @@ from typing import Any, Literal, Optional, Union
 from chonkie.embeddings import AutoEmbeddings, BaseEmbeddings
 from chonkie.logger import get_logger
 from chonkie.pipeline import handshake
-from chonkie.types import Chunk
+from chonkie.types import Chunk, Document
 
 from .base import BaseHandshake
 from .utils import generate_random_collection_name
@@ -87,19 +87,18 @@ class TurbopufferHandshake(BaseHandshake):
         """Check if Turbopuffer is available."""
         return importutil.find_spec("turbopuffer") is not None
 
-    def write(self, chunks: Union[Chunk, list[Chunk]]) -> None:
-        """Write the chunks to the Turbopuffer database."""
-        if isinstance(chunks, Chunk):
-            chunks = [chunks]
+    @staticmethod
+    def _embedding_to_list(embedding: Any) -> list[float]:
+        """Convert an embedding vector to a list."""
+        return embedding.tolist() if hasattr(embedding, "tolist") else list(embedding)
 
-        logger.debug(f"Writing {len(chunks)} chunks to Turbopuffer namespace: {self.namespace.id}")
-        # Embed the chunks
+    def _write_embedded_chunks(self, chunks: list[Chunk], embeddings: list[list[float]]) -> None:
+        """Write chunks and precomputed embeddings to Turbopuffer."""
         ids = [
             self._generate_id(f"{self.namespace.id}::chunk-{index}:{chunk.text}")
             for (index, chunk) in enumerate(chunks)
         ]
         texts = [chunk.text for chunk in chunks]
-        embeddings = [embedding.tolist() for embedding in self.embedding_model.embed_batch(texts)]
         start_indices = [chunk.start_index for chunk in chunks]
         end_indices = [chunk.end_index for chunk in chunks]
         token_counts = [chunk.token_count for chunk in chunks]
@@ -108,7 +107,6 @@ class TurbopufferHandshake(BaseHandshake):
             for chunk in chunks
         ]
 
-        # Write the chunks to the database
         self.namespace.write(
             upsert_columns={
                 "id": ids,
@@ -125,6 +123,39 @@ class TurbopufferHandshake(BaseHandshake):
         logger.info(
             f"Chonkie has written {len(chunks)} chunks to the namespace: {self.namespace.id}",
         )
+
+    def write(self, chunks: Union[Chunk, list[Chunk]]) -> None:
+        """Write the chunks to the Turbopuffer database."""
+        if isinstance(chunks, Chunk):
+            chunks = [chunks]
+
+        logger.debug(f"Writing {len(chunks)} chunks to Turbopuffer namespace: {self.namespace.id}")
+        texts = [chunk.text for chunk in chunks]
+        embeddings = [
+            self._embedding_to_list(embedding)
+            for embedding in self.embedding_model.embed_batch(texts)
+        ]
+        self._write_embedded_chunks(chunks, embeddings)
+
+    def write_documents(self, documents: list[Document]) -> None:
+        """Write document chunks while preserving document boundaries for embedding models."""
+        chunks_by_document = [document.chunks for document in documents]
+        chunks = [chunk for document_chunks in chunks_by_document for chunk in document_chunks]
+        if not chunks:
+            return
+
+        logger.debug(f"Writing {len(chunks)} chunks to Turbopuffer namespace: {self.namespace.id}")
+        if hasattr(self.embedding_model, "embed_documents"):
+            document_texts = [
+                [chunk.text for chunk in chunk_group]
+                for chunk_group in chunks_by_document
+            ]
+            raw_embeddings = self.embedding_model.embed_documents(document_texts)
+        else:
+            raw_embeddings = self.embedding_model.embed_batch([chunk.text for chunk in chunks])
+
+        embeddings = [self._embedding_to_list(embedding) for embedding in raw_embeddings]
+        self._write_embedded_chunks(chunks, embeddings)
 
     def __repr__(self) -> str:
         """Return the representation of the Turbopuffer Handshake."""

--- a/src/chonkie/pipeline/pipeline.py
+++ b/src/chonkie/pipeline/pipeline.py
@@ -810,8 +810,9 @@ class Pipeline:
                 isinstance(input_data, list)
                 and getattr(component, "preserves_document_boundaries", False) is True
             ):
-                if hasattr(component, "awrite_documents"):
-                    return await component.awrite_documents(input_data, **kwargs)
+                awrite_documents = getattr(component, "awrite_documents", None)
+                if inspect.iscoroutinefunction(awrite_documents):
+                    return await awrite_documents(input_data, **kwargs)
                 return await asyncio.to_thread(
                     component.write_documents,
                     input_data,

--- a/src/chonkie/pipeline/pipeline.py
+++ b/src/chonkie/pipeline/pipeline.py
@@ -740,6 +740,9 @@ class Pipeline:
             return input_data  # Return Documents for chaining
 
         if step_type == "write":
+            if isinstance(input_data, list) and hasattr(component, "write_documents"):
+                return component.write_documents(input_data, **kwargs)
+
             # Extract chunks and write to vector DB
             chunks = (
                 [c for doc in input_data for c in doc.chunks]
@@ -800,6 +803,16 @@ class Pipeline:
             return input_data
 
         if step_type == "write":
+            if isinstance(input_data, list):
+                if hasattr(component, "awrite_documents"):
+                    return await component.awrite_documents(input_data, **kwargs)
+                if hasattr(component, "write_documents"):
+                    return await asyncio.to_thread(
+                        component.write_documents,
+                        input_data,
+                        **kwargs,
+                    )
+
             chunks = (
                 [c for doc in input_data for c in doc.chunks]
                 if isinstance(input_data, list)

--- a/src/chonkie/pipeline/pipeline.py
+++ b/src/chonkie/pipeline/pipeline.py
@@ -740,7 +740,10 @@ class Pipeline:
             return input_data  # Return Documents for chaining
 
         if step_type == "write":
-            if isinstance(input_data, list) and hasattr(component, "write_documents"):
+            if (
+                isinstance(input_data, list)
+                and getattr(component, "preserves_document_boundaries", False) is True
+            ):
                 return component.write_documents(input_data, **kwargs)
 
             # Extract chunks and write to vector DB
@@ -803,15 +806,17 @@ class Pipeline:
             return input_data
 
         if step_type == "write":
-            if isinstance(input_data, list):
+            if (
+                isinstance(input_data, list)
+                and getattr(component, "preserves_document_boundaries", False) is True
+            ):
                 if hasattr(component, "awrite_documents"):
                     return await component.awrite_documents(input_data, **kwargs)
-                if hasattr(component, "write_documents"):
-                    return await asyncio.to_thread(
-                        component.write_documents,
-                        input_data,
-                        **kwargs,
-                    )
+                return await asyncio.to_thread(
+                    component.write_documents,
+                    input_data,
+                    **kwargs,
+                )
 
             chunks = (
                 [c for doc in input_data for c in doc.chunks]

--- a/tests/embeddings/test_catsu_embeddings.py
+++ b/tests/embeddings/test_catsu_embeddings.py
@@ -49,6 +49,12 @@ def sample_texts() -> List[str]:
     ]
 
 
+def _mock_contextual_response(embeddings_by_input: list[list[list[float]]]):
+    response = MagicMock()
+    response.embeddings = embeddings_by_input
+    return response
+
+
 def test_initialization_with_model_name(embedding_model: CatsuEmbeddings) -> None:
     """Test that CatsuEmbeddings initializes with a model name."""
     assert embedding_model.model == "voyage-3"
@@ -129,6 +135,72 @@ def test_embed_batch_empty_list(embedding_model: CatsuEmbeddings) -> None:
     embeddings = embedding_model.embed_batch([])
     assert isinstance(embeddings, list)
     assert len(embeddings) == 0
+
+
+def test_contextual_embed_uses_query_input_type(mock_catsu_client) -> None:
+    """Contextual Catsu embeds single text as a query."""
+    mock_catsu_client.contextualized_embed.return_value = _mock_contextual_response(
+        [[[0.1] * 512]],
+    )
+    with patch("catsu.Client", return_value=mock_catsu_client):
+        embeddings = CatsuEmbeddings(
+            model="voyage-context-3",
+            provider="voyageai",
+            dimensions=512,
+        )
+
+        result = embeddings.embed("find this")
+
+    mock_catsu_client.contextualized_embed.assert_called_once_with(
+        model="voyage-context-3",
+        inputs=[["find this"]],
+        provider="voyageai",
+        input_type="query",
+        dimensions=512,
+    )
+    assert result.shape == (512,)
+
+
+def test_contextual_embed_batch_preserves_single_document(mock_catsu_client) -> None:
+    """Contextual Catsu embeds a batch as chunks from one document."""
+    mock_catsu_client.contextualized_embed.return_value = _mock_contextual_response(
+        [[[0.1] * 1024, [0.2] * 1024]],
+    )
+    with patch("catsu.Client", return_value=mock_catsu_client):
+        embeddings = CatsuEmbeddings(model="voyage-context-3", provider="voyageai")
+
+        results = embeddings.embed_batch(["chunk 1", "chunk 2"])
+
+    mock_catsu_client.contextualized_embed.assert_called_once_with(
+        model="voyage-context-3",
+        inputs=[["chunk 1", "chunk 2"]],
+        provider="voyageai",
+        input_type="document",
+        dimensions=None,
+    )
+    assert len(results) == 2
+
+
+def test_contextual_embed_documents_preserves_document_groups(mock_catsu_client) -> None:
+    """Contextual Catsu embeds multiple document groups together."""
+    mock_catsu_client.contextualized_embed.return_value = _mock_contextual_response(
+        [[[0.1] * 1024, [0.2] * 1024], [[0.3] * 1024]],
+    )
+    with patch("catsu.Client", return_value=mock_catsu_client):
+        embeddings = CatsuEmbeddings(model="voyage-context-3", provider="voyageai")
+
+        results = embeddings.embed_documents(
+            [["doc 1 chunk 1", "doc 1 chunk 2"], ["doc 2 chunk 1"]],
+        )
+
+    mock_catsu_client.contextualized_embed.assert_called_once_with(
+        model="voyage-context-3",
+        inputs=[["doc 1 chunk 1", "doc 1 chunk 2"], ["doc 2 chunk 1"]],
+        provider="voyageai",
+        input_type="document",
+        dimensions=None,
+    )
+    assert len(results) == 3
 
 
 def test_embed_batch_with_batching(embedding_model: CatsuEmbeddings) -> None:

--- a/tests/embeddings/test_voyageai_embeddings.py
+++ b/tests/embeddings/test_voyageai_embeddings.py
@@ -113,18 +113,13 @@ def test_embed_batch_empty(embedding_model: VoyageAIEmbeddings) -> None:
 
 def _mock_contextual_response(embeddings_by_input: list[list[list[float]]]):
     response = MagicMock()
-    response.results = []
-    for embeddings in embeddings_by_input:
-        result = MagicMock()
-        result.embeddings = embeddings
-        response.results.append(result)
+    response.embeddings = embeddings_by_input
     return response
 
 
 def test_contextual_embed_batch_uses_contextual_endpoint() -> None:
     """Contextual models embed chunks together as one document."""
-    pytest.importorskip("voyageai")
-    with patch("voyageai.Client") as mock_client_class:
+    with patch("catsu.Client") as mock_client_class:
         mock_client = mock_client_class.return_value
         mock_client.contextualized_embed.return_value = _mock_contextual_response(
             [[[0.1] * 1024, [0.2] * 1024]],
@@ -134,10 +129,11 @@ def test_contextual_embed_batch_uses_contextual_endpoint() -> None:
         results = embeddings.embed_batch(["chunk 1", "chunk 2"])
 
     mock_client.contextualized_embed.assert_called_once_with(
-        inputs=[["chunk 1", "chunk 2"]],
         model="voyage-context-3",
+        inputs=[["chunk 1", "chunk 2"]],
+        provider="voyageai",
         input_type="document",
-        output_dimension=1024,
+        dimensions=1024,
     )
     assert len(results) == 2
     assert np.allclose(results[0], [0.1] * 1024)
@@ -145,8 +141,7 @@ def test_contextual_embed_batch_uses_contextual_endpoint() -> None:
 
 def test_contextual_embed_documents_preserves_document_groups() -> None:
     """Contextual models can embed multiple document chunk groups together."""
-    pytest.importorskip("voyageai")
-    with patch("voyageai.Client") as mock_client_class:
+    with patch("catsu.Client") as mock_client_class:
         mock_client = mock_client_class.return_value
         mock_client.contextualized_embed.return_value = _mock_contextual_response(
             [[[0.1] * 512, [0.2] * 512], [[0.3] * 512]],
@@ -162,10 +157,11 @@ def test_contextual_embed_documents_preserves_document_groups() -> None:
         )
 
     mock_client.contextualized_embed.assert_called_once_with(
-        inputs=[["doc 1 chunk 1", "doc 1 chunk 2"], ["doc 2 chunk 1"]],
         model="voyage-context-3",
+        inputs=[["doc 1 chunk 1", "doc 1 chunk 2"], ["doc 2 chunk 1"]],
+        provider="voyageai",
         input_type="document",
-        output_dimension=512,
+        dimensions=512,
     )
     assert embeddings.dimension == 512
     assert len(results) == 3
@@ -173,8 +169,7 @@ def test_contextual_embed_documents_preserves_document_groups() -> None:
 
 def test_contextual_embed_single_text_uses_query_input_type() -> None:
     """Single contextual embeds are treated as query embeddings."""
-    pytest.importorskip("voyageai")
-    with patch("voyageai.Client") as mock_client_class:
+    with patch("catsu.Client") as mock_client_class:
         mock_client = mock_client_class.return_value
         mock_client.contextualized_embed.return_value = _mock_contextual_response(
             [[[0.1] * 1024]],
@@ -184,17 +179,17 @@ def test_contextual_embed_single_text_uses_query_input_type() -> None:
         result = embeddings.embed("find this")
 
     mock_client.contextualized_embed.assert_called_once_with(
-        inputs=[["find this"]],
         model="voyage-context-3",
+        inputs=[["find this"]],
+        provider="voyageai",
         input_type="query",
-        output_dimension=1024,
+        dimensions=1024,
     )
     assert result.shape == (1024,)
 
 
 def test_contextual_invalid_output_dimension_raises() -> None:
     """Contextual models validate their supported output dimensions."""
-    pytest.importorskip("voyageai")
     with pytest.raises(ValueError, match="Invalid output_dimension"):
         VoyageAIEmbeddings(
             model="voyage-context-3",

--- a/tests/embeddings/test_voyageai_embeddings.py
+++ b/tests/embeddings/test_voyageai_embeddings.py
@@ -111,6 +111,98 @@ def test_embed_batch_empty(embedding_model: VoyageAIEmbeddings) -> None:
     assert results == []
 
 
+def _mock_contextual_response(embeddings_by_input: list[list[list[float]]]):
+    response = MagicMock()
+    response.results = []
+    for embeddings in embeddings_by_input:
+        result = MagicMock()
+        result.embeddings = embeddings
+        response.results.append(result)
+    return response
+
+
+def test_contextual_embed_batch_uses_contextual_endpoint() -> None:
+    """Contextual models embed chunks together as one document."""
+    pytest.importorskip("voyageai")
+    with patch("voyageai.Client") as mock_client_class:
+        mock_client = mock_client_class.return_value
+        mock_client.contextualized_embed.return_value = _mock_contextual_response(
+            [[[0.1] * 1024, [0.2] * 1024]],
+        )
+        embeddings = VoyageAIEmbeddings(model="voyage-context-3", api_key="test-key")
+
+        results = embeddings.embed_batch(["chunk 1", "chunk 2"])
+
+    mock_client.contextualized_embed.assert_called_once_with(
+        inputs=[["chunk 1", "chunk 2"]],
+        model="voyage-context-3",
+        input_type="document",
+        output_dimension=1024,
+    )
+    assert len(results) == 2
+    assert np.allclose(results[0], [0.1] * 1024)
+
+
+def test_contextual_embed_documents_preserves_document_groups() -> None:
+    """Contextual models can embed multiple document chunk groups together."""
+    pytest.importorskip("voyageai")
+    with patch("voyageai.Client") as mock_client_class:
+        mock_client = mock_client_class.return_value
+        mock_client.contextualized_embed.return_value = _mock_contextual_response(
+            [[[0.1] * 512, [0.2] * 512], [[0.3] * 512]],
+        )
+        embeddings = VoyageAIEmbeddings(
+            model="voyage-context-3",
+            api_key="test-key",
+            output_dimension=512,
+        )
+
+        results = embeddings.embed_documents(
+            [["doc 1 chunk 1", "doc 1 chunk 2"], ["doc 2 chunk 1"]],
+        )
+
+    mock_client.contextualized_embed.assert_called_once_with(
+        inputs=[["doc 1 chunk 1", "doc 1 chunk 2"], ["doc 2 chunk 1"]],
+        model="voyage-context-3",
+        input_type="document",
+        output_dimension=512,
+    )
+    assert embeddings.dimension == 512
+    assert len(results) == 3
+
+
+def test_contextual_embed_single_text_uses_query_input_type() -> None:
+    """Single contextual embeds are treated as query embeddings."""
+    pytest.importorskip("voyageai")
+    with patch("voyageai.Client") as mock_client_class:
+        mock_client = mock_client_class.return_value
+        mock_client.contextualized_embed.return_value = _mock_contextual_response(
+            [[[0.1] * 1024]],
+        )
+        embeddings = VoyageAIEmbeddings(model="voyage-context-3", api_key="test-key")
+
+        result = embeddings.embed("find this")
+
+    mock_client.contextualized_embed.assert_called_once_with(
+        inputs=[["find this"]],
+        model="voyage-context-3",
+        input_type="query",
+        output_dimension=1024,
+    )
+    assert result.shape == (1024,)
+
+
+def test_contextual_invalid_output_dimension_raises() -> None:
+    """Contextual models validate their supported output dimensions."""
+    pytest.importorskip("voyageai")
+    with pytest.raises(ValueError, match="Invalid output_dimension"):
+        VoyageAIEmbeddings(
+            model="voyage-context-3",
+            api_key="test-key",
+            output_dimension=300,  # type: ignore[arg-type]
+        )
+
+
 def test_dimension_property(embedding_model: VoyageAIEmbeddings) -> None:
     """Test that dimension property works."""
     assert isinstance(embedding_model.dimension, int)

--- a/tests/handshakes/test_turbopuffer_handshake.py
+++ b/tests/handshakes/test_turbopuffer_handshake.py
@@ -175,8 +175,11 @@ def test_turbopuffer_write_documents_uses_document_embeddings(
 
     mock_embeddings_tpuf.embed_documents.assert_called_once_with([["a", "b"], ["c"]])
     assert ns.last_write["upsert_columns"]["text"] == ["a", "b", "c"]
-    assert ns.last_write["upsert_columns"]["vector"] == [
-        [0.1, 0.2],
-        [0.3, 0.4],
-        [0.5, 0.6],
-    ]
+    np.testing.assert_allclose(
+        ns.last_write["upsert_columns"]["vector"],
+        [
+            [0.1, 0.2],
+            [0.3, 0.4],
+            [0.5, 0.6],
+        ],
+    )

--- a/tests/handshakes/test_turbopuffer_handshake.py
+++ b/tests/handshakes/test_turbopuffer_handshake.py
@@ -11,7 +11,7 @@ from unittest.mock import MagicMock, patch
 import numpy as np
 import pytest
 
-from chonkie.types import Chunk
+from chonkie.types import Chunk, Document
 
 
 class _FakeNamespace:
@@ -140,3 +140,43 @@ def test_turbopuffer_repr(
     ns = _FakeNamespace("my-id")
     hs = TurbopufferHandshake(namespace=ns, api_key="k")
     assert "my-id" in repr(hs)
+
+
+def test_turbopuffer_write_documents_uses_document_embeddings(
+    fake_turbopuffer_module,
+    mock_embeddings_tpuf,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Document-aware writes preserve chunk groups for contextual embedders."""
+    monkeypatch.setenv("TURBOPUFFER_API_KEY", "k")
+    from chonkie.handshakes.turbopuffer import TurbopufferHandshake
+
+    mock_embeddings_tpuf.embed_documents.return_value = np.array(
+        [[0.1, 0.2], [0.3, 0.4], [0.5, 0.6]],
+        dtype=np.float32,
+    )
+    ns = _FakeNamespace("fixed-ns")
+    hs = TurbopufferHandshake(namespace=ns, api_key="k")
+    documents = [
+        Document(
+            content="doc one",
+            chunks=[
+                Chunk(text="a", start_index=0, end_index=1, token_count=1),
+                Chunk(text="b", start_index=1, end_index=2, token_count=1),
+            ],
+        ),
+        Document(
+            content="doc two",
+            chunks=[Chunk(text="c", start_index=0, end_index=1, token_count=1)],
+        ),
+    ]
+
+    hs.write_documents(documents)
+
+    mock_embeddings_tpuf.embed_documents.assert_called_once_with([["a", "b"], ["c"]])
+    assert ns.last_write["upsert_columns"]["text"] == ["a", "b", "c"]
+    assert ns.last_write["upsert_columns"]["vector"] == [
+        [0.1, 0.2],
+        [0.3, 0.4],
+        [0.5, 0.6],
+    ]

--- a/tests/pipeline/test_pipeline_coverage.py
+++ b/tests/pipeline/test_pipeline_coverage.py
@@ -723,6 +723,24 @@ class TestPipelineAsync:
         doc2.chunks = [MagicMock()]
         component.awrite = AsyncMock(return_value="written")
         result = await pipeline._acall_component(component, "write", [doc1, doc2], {})
+        component.awrite.assert_called_once()
+        assert result == "written"
+
+    @pytest.mark.asyncio
+    async def test_acall_component_write_list_document_writer(self):
+        """_acall_component uses document-aware writer when opted in."""
+        pipeline = Pipeline()
+        component = MagicMock()
+        component.preserves_document_boundaries = True
+        component.write_documents.return_value = "written"
+        doc1 = MagicMock()
+        doc1.chunks = [MagicMock()]
+        doc2 = MagicMock()
+        doc2.chunks = [MagicMock()]
+
+        result = await pipeline._acall_component(component, "write", [doc1, doc2], {})
+
+        component.write_documents.assert_called_once_with([doc1, doc2])
         assert result == "written"
 
 
@@ -748,6 +766,22 @@ class TestPipelineCallComponentWriteExport:
         doc2.chunks = [MagicMock()]
         component.write.return_value = "result"
         result = pipeline._call_component(component, "write", [doc1, doc2], {})
+        component.write.assert_called_once()
+        assert result == "result"
+
+    def test_write_step_list_uses_document_writer_when_opted_in(self):
+        pipeline = Pipeline()
+        component = MagicMock()
+        component.preserves_document_boundaries = True
+        component.write_documents.return_value = "result"
+        doc1 = MagicMock()
+        doc1.chunks = [MagicMock()]
+        doc2 = MagicMock()
+        doc2.chunks = [MagicMock()]
+
+        result = pipeline._call_component(component, "write", [doc1, doc2], {})
+
+        component.write_documents.assert_called_once_with([doc1, doc2])
         assert result == "result"
 
     def test_export_step_list_of_docs(self):


### PR DESCRIPTION
## Summary
- add `voyage-context-3` support through `VoyageAIEmbeddings`, backed by Catsu
- add document-group embedding support to `CatsuEmbeddings` for contextual models
- route opted-in pipeline handshakes through `write_documents`, and make Turbopuffer preserve document boundaries before embedding chunks

## Dependency
- depends on Catsu contextual embedding support in https://github.com/chonkie-inc/catsu/pull/32 before this can be released against a published `catsu` version

## Test plan
- [x] mocked Catsu and Voyage contextual embedding paths
- [x] Turbopuffer document-boundary write path
- [x] pipeline sync/async document-aware write routing
- [x] Ruff check and format check on touched files
- [x] live Voyage smoke: Catsu and Voyage wrappers returned three document vectors and 256-dim query vectors

## Notes
- once Catsu PR #32 is released, the Chonkie dependency lower bound can be tightened to the released version if desired