### PR TITLE
chore: add instructions on how to use skills 

### DIFF
--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   trufflehog:
     runs-on: ubuntu-latest

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -1,0 +1,20 @@
+name: TruffleHog Secret Scan
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  trufflehog:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: TruffleHog scan
+        uses: trufflesecurity/trufflehog@main
+        with:
+          extra_args: --only-verified

--- a/README.md
+++ b/README.md
@@ -334,6 +334,24 @@ Additional utilities to enhance your chunking workflow.
 
 With Chonkie's wide range of integrations, you can easily plug it into your existing infrastructure and start CHONKING!
 
+## 🤖 AI Agent Skills & Plugins
+
+Chonkie provides an official skill and plugin for AI coding agents, giving them deep knowledge of Chonkie's API, chunking strategies, and pipeline patterns — so they can help you build RAG pipelines faster.
+
+**Supported agents:** Claude Code, Cursor, Gemini CLI, and more.
+
+```bash
+# Via skills.sh (works with Claude Code, Cursor, Copilot, and 20+ agents)
+npx skills add chonkie-inc/skills
+
+# Claude Code only
+/plugin marketplace add chonkie-inc/skills
+```
+
+Once installed, your agent gains knowledge of all chunkers, the Pipeline API, tokenizer selection, embeddings refineries, vector DB handshakes, the REST API server, recipes, and async/batch processing patterns.
+
+Learn more at [github.com/chonkie-inc/skills](https://github.com/chonkie-inc/skills).
+
 ## 📊 Benchmarks
 
 > "I may be smol hippo, but I pack a big punch!" 🦛

--- a/docs/common/welcome.mdx
+++ b/docs/common/welcome.mdx
@@ -7,6 +7,10 @@ iconType: "solid"
 mode: "wide"
 ---
 
+<Banner title="NEW: AI Agent Skills for Chonkie" href="https://github.com/chonkie-inc/skills">
+  Install via npx skills add chonkie-inc/skills or browse on skills.sh — works with 20+ AI coding agents.
+</Banner>
+
 <div className="flex justify-center">
   <img
     className="block dark:hidden"
@@ -49,6 +53,9 @@ Well, look no further than Chonkie! (chonkie boi is a gud boi 🦛)
   </Card>
   <Card title="Cute Mascot" icon="hippo">
     psst it's a pygmy hippo btw! Moto Moto approved
+  </Card>
+  <Card title="AI Agent Skills" icon="robot" href="https://github.com/chonkie-inc/skills">
+    Install via `npx skills add chonkie-inc/skills` or browse on skills.sh — works with Claude Code, Cursor, Copilot, and 20+ agents
   </Card>
 </CardGroup>
 ---


### PR DESCRIPTION
we now have skills 🥳  [![skills.sh](https://skills.sh/b/chonkie-inc/skills)](https://skills.sh/chonkie-inc/skills)
These skills are available in https://skills.sh/chonkie-inc/skills 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
- Added comprehensive documentation section detailing AI Agent Skills & Plugins, including supported agents and installation instructions.
- Added promotional content introducing AI Agent Skills with compatibility information and setup guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->