### PR TITLE
fix: replace bare except with except Exception in types/base.py

### DIFF
--- a/src/chonkie/types/base.py
+++ b/src/chonkie/types/base.py
@@ -79,7 +79,7 @@ class Chunk:
                 return preview
             else:
                 return str(self.embedding)
-        except:
+        except Exception:
             return "<embedding>"
 
     def __repr__(self) -> str:


### PR DESCRIPTION
Replaces bare `except:` with `except Exception:` in `src/chonkie/types/base.py` (line 82).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in embedding preview formatting to prevent unintended fallback behaviors and provide more precise error detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->