### PR TITLE
fix(code): support tree-sitter-language-pack >= 1.8.0

### DIFF
--- a/src/chonkie/chunker/code.py
+++ b/src/chonkie/chunker/code.py
@@ -77,16 +77,32 @@ class CodeChunker(BaseChunker):
             self.magika = Magika()
             self.parser = None
         else:
-            from tree_sitter_language_pack import SupportedLanguage, get_parser
+            from tree_sitter_language_pack import get_parser
 
             try:
-                self.parser = get_parser(cast(SupportedLanguage, language))
-            except LookupError as e:
-                raise ValueError(
-                    f"Unsupported language '{language}'. "
-                    f"Supported languages are: {list(get_args(SupportedLanguage))}. "
-                    "Or set language='auto'."
-                ) from e
+                from tree_sitter_language_pack import SupportedLanguage
+                supported = list(get_args(SupportedLanguage))
+            except ImportError:
+                # tree-sitter-language-pack >= 1.8.0 removed the
+                # SupportedLanguage Literal alias.
+                supported = []
+
+            try:
+                self.parser = get_parser(cast(str, language))
+            except (LookupError, RuntimeError) as e:
+                if supported:
+                    msg = (
+                        f"Unsupported language '{language}'. "
+                        f"Supported languages are: {supported}. "
+                        "Or set language='auto'."
+                    )
+                else:
+                    msg = (
+                        f"Unsupported language '{language}'. "
+                        "See tree_sitter_language_pack for the supported "
+                        "languages, or set language='auto'."
+                    )
+                raise ValueError(msg) from e
 
         # Set the use_multiprocessing flag
         self._use_multiprocessing = False
@@ -371,10 +387,10 @@ class CodeChunker(BaseChunker):
     def _chunk_code_block(self, content: str, language: str | None) -> list[Chunk]:
         """Chunk a single code block, using the block's language hint when available."""
         if language and self.language == "auto":
-            from tree_sitter_language_pack import SupportedLanguage, get_parser
+            from tree_sitter_language_pack import get_parser
 
             try:
-                parser = get_parser(cast(SupportedLanguage, language))
+                parser = get_parser(cast(str, language))
                 original_parser = self.parser
                 original_language = self.language
                 self.parser = parser

--- a/tests/chunkers/test_code_chunker.py
+++ b/tests/chunkers/test_code_chunker.py
@@ -59,6 +59,18 @@ def test_code_chunker_initialization() -> None:
     assert chunker.parser is not None
 
 
+def test_code_chunker_unsupported_language_raises_value_error() -> None:
+    """Unsupported languages raise ValueError, not a tree-sitter error.
+
+    Regression test for #583: tree-sitter-language-pack >= 1.8.0 removed
+    the `SupportedLanguage` Literal and raises `RuntimeError` (instead of
+    `LookupError`) for unknown languages. CodeChunker must still surface
+    a `ValueError` to callers.
+    """
+    with pytest.raises(ValueError, match="Unsupported language"):
+        CodeChunker(language="definitely_not_a_real_language")
+
+
 def test_code_chunker_chunking_python(python_code: str) -> None:
     """Test basic chunking of Python code."""
     chunker = CodeChunker(language="python", chunk_size=50, include_nodes=True)


### PR DESCRIPTION
Closes #583.

`tree-sitter-language-pack` 1.8.0 dropped the `SupportedLanguage` Literal alias and now raises `RuntimeError` (instead of `LookupError`) when `get_parser` is given an unknown language. `CodeChunker` imported `SupportedLanguage` at module init, so the import itself failed under the new version:

```
ImportError: cannot import name 'SupportedLanguage' from 'tree_sitter_language_pack'
```

Made the import conditional so the chunker keeps working on both pre-1.8 and 1.8+: `SupportedLanguage` is only imported when present, and the lookup error handler now catches both `LookupError` and `RuntimeError`. The error message still lists the supported languages when the Literal is available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for unsupported programming languages in code chunking, returning clearer, user-friendly error messages and preventing low-level parser errors from surfacing.

* **Tests**
  * Added a regression test to ensure an invalid language selection reliably raises a clear ValueError.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chonkie-inc/chonkie/pull/586)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->