### PR TITLE
Fix: initial CodeChunker languages downloaded

### DIFF
--- a/src/chonkie/chunker/code.py
+++ b/src/chonkie/chunker/code.py
@@ -115,6 +115,7 @@ class CodeChunker(BaseChunker):
             )
         else:
             from tree_sitter_language_pack import download, has_language
+
             # backward compatibility: if the language is not downloaded yet
             # since this is recently made we can get rid of this block in the future
             if not has_language(language):

--- a/src/chonkie/chunker/code.py
+++ b/src/chonkie/chunker/code.py
@@ -103,7 +103,7 @@ class CodeChunker(BaseChunker):
         # in version 1.6.6, when we ran the tests we downloaded 19 languages
         # this will download the rest of them for all onward versions
         # but it won't redownload for users who already have 19 or more languages downloaded
-        if num_languages < 19:
+        if num_languages <= 19:
             logger.info("Downloading tree-sitter languages for the first time...")
             download_all()
 

--- a/src/chonkie/chunker/code.py
+++ b/src/chonkie/chunker/code.py
@@ -95,6 +95,19 @@ class CodeChunker(BaseChunker):
         self.include_nodes = include_nodes
 
         self.language = language
+
+        # download tree_sitter_languages for first time when we use the chunker
+        from tree_sitter_language_pack import download_all, downloaded_languages
+
+        num_languages = len(downloaded_languages())
+        # in version 1.6.6, when we ran the tests we downloaded 19 languages
+        # this will download the rest of them for all onward versions
+        # but it won't redownload for users who already have 19 or more languages downloaded
+        if num_languages < 19:
+            logger.info("Downloading tree-sitter languages for the first time...")
+            download_all()
+
+        # load the language
         if language == "auto":
             logger.warning(
                 "The language is set to `auto`. This would adversely affect the performance of the chunker. "
@@ -102,7 +115,8 @@ class CodeChunker(BaseChunker):
             )
         else:
             from tree_sitter_language_pack import download, has_language
-
+            # backward compatibility: if the language is not downloaded yet
+            # since this is recently made we can get rid of this block in the future
             if not has_language(language):
                 download([language])
 


### PR DESCRIPTION
this pr will download all the possible languages for the CodeChunker

This is a follow up to https://github.com/chonkie-inc/chonkie/issues/583#issuecomment-4448807389

This spirit behind this pr is inspired by the minor code snippet below

<img width="1212" height="575" alt="image" src="https://github.com/user-attachments/assets/ed8b6a19-166b-4bb3-9feb-838721c015a4" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved code chunker initialization reliability by automatically ensuring language grammars are available on first use.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chonkie-inc/chonkie/pull/591)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->