### PR TITLE
fix: write non-ASCII text as-is in JSON export instead of \uXXXX escapes

### DIFF
--- a/src/chonkie/porters/json.py
+++ b/src/chonkie/porters/json.py
@@ -30,16 +30,16 @@ class JSONPorter(BasePorter):
     def _export_lines(self, chunks: list[Chunk], file: str | os.PathLike = "chunks.jsonl") -> None:
         """Export the Chunks as a JSONL file."""
         logger.debug(f"Exporting {len(chunks)} chunks to JSONL file: {file}")
-        with open(file, "w") as f:
+        with open(file, "w", encoding="utf-8") as f:
             for chunk in chunks:
-                f.write(json.dumps(chunk.to_dict()) + "\n")
+                f.write(json.dumps(chunk.to_dict(), ensure_ascii=False) + "\n")
         logger.info(f"Successfully exported {len(chunks)} chunks to JSONL: {file}")
 
     def _export_json(self, chunks: list[Chunk], file: str | os.PathLike = "chunks.json") -> None:
         """Export the Chunks into a JSON string."""
         logger.debug(f"Exporting {len(chunks)} chunks to JSON file: {file}")
-        with open(file, "w") as f:
-            json.dump([chunk.to_dict() for chunk in chunks], f, indent=self.indent)
+        with open(file, "w", encoding="utf-8") as f:
+            json.dump([chunk.to_dict() for chunk in chunks], f, indent=self.indent, ensure_ascii=False)
         logger.info(f"Successfully exported {len(chunks)} chunks to JSON: {file}")
 
     def export(self, chunks: list[Chunk], file: str | os.PathLike = "chunks.jsonl") -> None:  # type: ignore[override]

--- a/src/chonkie/porters/json.py
+++ b/src/chonkie/porters/json.py
@@ -39,7 +39,9 @@ class JSONPorter(BasePorter):
         """Export the Chunks into a JSON string."""
         logger.debug(f"Exporting {len(chunks)} chunks to JSON file: {file}")
         with open(file, "w", encoding="utf-8") as f:
-            json.dump([chunk.to_dict() for chunk in chunks], f, indent=self.indent, ensure_ascii=False)
+            json.dump(
+                [chunk.to_dict() for chunk in chunks], f, indent=self.indent, ensure_ascii=False
+            )
         logger.info(f"Successfully exported {len(chunks)} chunks to JSON: {file}")
 
     def export(self, chunks: list[Chunk], file: str | os.PathLike = "chunks.jsonl") -> None:  # type: ignore[override]

--- a/tests/porters/test_json_porter.py
+++ b/tests/porters/test_json_porter.py
@@ -296,7 +296,7 @@ def test_json_porter_unicode_content(tmp_path: Path) -> None:
 
 
 def test_json_porter_non_ascii_written_as_is_json(tmp_path: Path) -> None:
-    """Test that non-ASCII characters are written as-is, not as \\uXXXX escapes, in JSON format."""
+    r"""Test that non-ASCII characters are written as-is, not as \uXXXX escapes, in JSON format."""
     chunk = Chunk(
         text="Hello 世界! The quick brown fox 跳过了那只懒惰的狗。",
         start_index=0,
@@ -317,7 +317,7 @@ def test_json_porter_non_ascii_written_as_is_json(tmp_path: Path) -> None:
 
 
 def test_json_porter_non_ascii_written_as_is_jsonl(tmp_path: Path) -> None:
-    """Test that non-ASCII characters are written as-is, not as \\uXXXX escapes, in JSONL format."""
+    r"""Test that non-ASCII characters are written as-is, not as \uXXXX escapes, in JSONL format."""
     chunk = Chunk(
         text="Hello 世界! The quick brown fox 跳过了那只懒惰的狗。",
         start_index=0,

--- a/tests/porters/test_json_porter.py
+++ b/tests/porters/test_json_porter.py
@@ -295,6 +295,48 @@ def test_json_porter_unicode_content(tmp_path: Path) -> None:
     assert data[1]["text"] == "Café, naïve, résumé, 北京"
 
 
+def test_json_porter_non_ascii_written_as_is_json(tmp_path: Path) -> None:
+    """Test that non-ASCII characters are written as-is, not as \\uXXXX escapes, in JSON format."""
+    chunk = Chunk(
+        text="Hello 世界! The quick brown fox 跳过了那只懒惰的狗。",
+        start_index=0,
+        end_index=80,
+        token_count=12,
+    )
+
+    porter = JSONPorter(lines=False)
+    output_file = tmp_path / "non_ascii.json"
+    porter.export([chunk], str(output_file))
+
+    raw_content = output_file.read_text(encoding="utf-8")
+
+    # Verify the raw file contains the original characters, not escapes
+    assert "世界" in raw_content
+    assert "跳过了那只懒惰的狗" in raw_content
+    assert "\\u" not in raw_content
+
+
+def test_json_porter_non_ascii_written_as_is_jsonl(tmp_path: Path) -> None:
+    """Test that non-ASCII characters are written as-is, not as \\uXXXX escapes, in JSONL format."""
+    chunk = Chunk(
+        text="Hello 世界! The quick brown fox 跳过了那只懒惰的狗。",
+        start_index=0,
+        end_index=80,
+        token_count=12,
+    )
+
+    porter = JSONPorter(lines=True)
+    output_file = tmp_path / "non_ascii.jsonl"
+    porter.export([chunk], str(output_file))
+
+    raw_content = output_file.read_text(encoding="utf-8")
+
+    # Verify the raw file contains the original characters, not escapes
+    assert "世界" in raw_content
+    assert "跳过了那只懒惰的狗" in raw_content
+    assert "\\u" not in raw_content
+
+
 def test_json_porter_chunk_serialization_completeness(
     sample_chunks: list[Chunk],
     tmp_path: Path,


### PR DESCRIPTION
## Summary
  
  `JSONPorter` previously wrote non-ASCII characters (CJK, Japanese, etc.) as
  `\uXXXX` Unicode escape sequences, making exported files unreadable. This PR
  fixes the issue with two changes:
  - Add `ensure_ascii=False` to `json.dumps`/`json.dump` so characters are written as-is
  - Add explicit `encoding="utf-8"` to `open()` for cross-platform consistency

  ## Before / After
  
  **Before** (non-ASCII text becomes `\uXXXX` escapes):
```json
  {"id": "chnk_...", "text": "The quick brown fox \u8df3\u8fc7\u4e86\u90a3\u53ea\u61d2\u60f0\u7684\u72d7\u3002\u4eca\u65e5\u306f\u3068\u3066\u3082\u826f\u3044\u5929\u6c17\u3067\u3059\u306d\u3002Machine learning (\u673a\u5668\u5b66\u4e60,
  \u6a5f\u68b0\u5b66\u7fd2)", ...}  
```
  
  After (original characters preserved):
```json
{"id": "chnk_...", "text": "The quick brown fox 跳过了那只懒惰的狗。今日はとても良い天気ですね。Machine learning (机器学习, 機械学習)", ...}
```
  Test plan

  - [x] Tested with mixed Chinese, Japanese, and English text — JSON export preserves original characters
  - [x] Pure ASCII text exports are unaffected
  - [x] Verified Pipeline flow works end-to-end:
  Pipeline()
      .fetch_from("file", path="document.txt")
      .process_with("text")
      .chunk_with("recursive", chunk_size=128)
      .export_with("json", file="chunks.json")
      .run()

  Affected files

  src/chonkie/porters/json.py — _export_lines() and _export_json() methods

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * JSON and JSONL exports now preserve non‑ASCII characters by writing files with UTF‑8 encoding and producing unescaped JSON output, ensuring characters like Chinese text appear correctly.
* **Tests**
  * Added tests that verify non‑ASCII characters are written as‑is for both JSON and JSONL exports, checking raw file contents to prevent escaped sequences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->