### PR TITLE
docs: add Requesty as an OpenAI-compatible provider example

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,16 @@ genie = OpenAIGenie(model="meta-llama/llama-4-maverick",
                     api_key="your_api_key")
 ```
 
+Or, here's how to use the `OpenAIGenie` to interact with the `gpt-4o-mini` model via Requesty:
+
+```python
+from chonkie import OpenAIGenie
+
+genie = OpenAIGenie(model="openai/gpt-4o-mini",
+                    base_url="https://router.requesty.ai/v1",
+                    api_key="your_api_key")
+```
+
 </details>
 
 <details>


### PR DESCRIPTION
This adds a Requesty example beside the existing OpenRouter one for `OpenAIGenie` in the README.

Requesty is an OpenAI-compatible LLM gateway, so it works with `OpenAIGenie` by setting `base_url="https://router.requesty.ai/v1"` and using `provider/model` naming (e.g. `openai/gpt-4o-mini`). The new snippet mirrors the existing OpenRouter example as closely as possible.

I verified a live chat completion against `https://router.requesty.ai/v1/chat/completions` with `openai/gpt-4o-mini` (HTTP 200, real completion returned), which is exactly the `base_url` + `model` combination shown in the example.

Links:
- https://requesty.ai
- https://docs.requesty.ai

I work at Requesty. This mirrors the existing OpenRouter example as closely as possible. Happy to adjust or close it if it's not a fit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Extended documentation with an example demonstrating OpenAIGenie configuration for the gpt-4o-mini model using Requesty integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->