### PR TITLE
chore: fix url in docs

### DIFF
--- a/docs/content/docs/chonkie/utils/visualizer.mdx
+++ b/docs/content/docs/chonkie/utils/visualizer.mdx
@@ -5,7 +5,7 @@ description: "Visualize your chunks and embeddings"
 
 The `Visualizer` helps you visualize your chunks properly and compare different chunkers and settings with ease, either on the terminal or via HTML.
 
-![Visualizer Example](https://raw.githubusercontent.com/chonkie-inc/chonkie/main/docs/assets/viz/viz-terminal.png)
+![Visualizer Example](https://raw.githubusercontent.com/feyninc/chonkie/main/docs/assets/viz/viz-terminal.png)
 
 ## Installation
 
@@ -47,4 +47,4 @@ The `save` method will save the chunks to a HTML file. Like `print`, it accepts 
 viz.save("chonkie.html", chunks)
 ```
 
-![Visualizer Example](https://raw.githubusercontent.com/chonkie-inc/chonkie/main/docs/assets/viz/viz-html.png)
+![Visualizer Example](https://raw.githubusercontent.com/feyninc/chonkie/main/docs/assets/viz/viz-html.png)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Visualizer docs screenshots to point to the latest image locations.
  * Refreshed the terminal and HTML example images in the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->