### PR TITLE
chore: fix url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,5 @@ data/
 *.db
 *.db-shm
 *.db-wal
+.vercel
+.env*

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -147,3 +147,5 @@ vite.config.ts.timestamp-*
 .source
 .playwright-mcp
 chonkiejs/content/
+.vercel
+.env*

--- a/docs/app/layout.tsx
+++ b/docs/app/layout.tsx
@@ -16,7 +16,7 @@ export const metadata: Metadata = {
   description:
     "The lightweight ingestion library for fast, efficient and robust RAG pipelines",
   icons: {
-    icon: "https://www.chonkie.ai/chonkies/chonkie_icon.svg",
+    icon: "/assets/logo/chonkie_logo_br_transparent_bg.png",
   },
   openGraph: {
     title: "Chonkie Documentation",

--- a/docs/components/product-switcher.tsx
+++ b/docs/components/product-switcher.tsx
@@ -12,18 +12,18 @@ import {
   switchProductHref,
 } from "@/lib/product-routes";
 
-const CHONKIE_ICON = "https://www.chonkie.ai/chonkies/chonkie_icon.svg";
+const CHONKIE_ICON = "/assets/logo/chonkie_logo_br_transparent_bg.png";
 
 function ProductIcon({ badge }: { badge: string | null }) {
   if (!badge) {
     return (
-      <img src={CHONKIE_ICON} alt="" width={18} height={18} className="shrink-0" />
+      <img src={CHONKIE_ICON} alt="" width={18} height={18} className="shrink-0 object-contain" />
     );
   }
 
   return (
     <div className="relative shrink-0">
-      <img src={CHONKIE_ICON} alt="" width={18} height={18} />
+      <img src={CHONKIE_ICON} alt="" width={18} height={18} className="object-contain" />
       <span className="absolute -bottom-0.5 -right-1 text-[7px] font-bold leading-none bg-fd-primary text-fd-primary-foreground rounded px-0.5">
         {badge}
       </span>

--- a/docs/content/docs/chonkie/utils/visualizer.mdx
+++ b/docs/content/docs/chonkie/utils/visualizer.mdx
@@ -5,7 +5,7 @@ description: "Visualize your chunks and embeddings"
 
 The `Visualizer` helps you visualize your chunks properly and compare different chunkers and settings with ease, either on the terminal or via HTML.
 
-![Visualizer Example](https://raw.githubusercontent.com/feyninc/chonkie/main/docs/assets/viz/viz-terminal.png)
+![Visualizer Example](https://raw.githubusercontent.com/feyninc/chonkie/main/docs/public/assets/viz/viz-terminal.png)
 
 ## Installation
 
@@ -47,4 +47,4 @@ The `save` method will save the chunks to a HTML file. Like `print`, it accepts 
 viz.save("chonkie.html", chunks)
 ```
 
-![Visualizer Example](https://raw.githubusercontent.com/feyninc/chonkie/main/docs/assets/viz/viz-html.png)
+![Visualizer Example](https://raw.githubusercontent.com/feyninc/chonkie/main/docs/public/assets/viz/viz-html.png)

--- a/docs/content/docs/chonkie/utils/visualizer.mdx
+++ b/docs/content/docs/chonkie/utils/visualizer.mdx
@@ -5,7 +5,7 @@ description: "Visualize your chunks and embeddings"
 
 The `Visualizer` helps you visualize your chunks properly and compare different chunkers and settings with ease, either on the terminal or via HTML.
 
-![Visualizer Example](https://raw.githubusercontent.com/feyninc/chonkie/main/docs/public/assets/viz/viz-terminal.png)
+![Visualizer Example](/assets/viz/viz-terminal.png)
 
 ## Installation
 
@@ -47,4 +47,4 @@ The `save` method will save the chunks to a HTML file. Like `print`, it accepts 
 viz.save("chonkie.html", chunks)
 ```
 
-![Visualizer Example](https://raw.githubusercontent.com/feyninc/chonkie/main/docs/public/assets/viz/viz-html.png)
+![Visualizer Example](/assets/viz/viz-html.png)

--- a/docs/lib/layout.shared.tsx
+++ b/docs/lib/layout.shared.tsx
@@ -5,11 +5,11 @@ export const baseOptions: BaseLayoutProps = {
     title: (
       <>
         <img
-          src="https://www.chonkie.ai/chonkies/chonkie_icon.svg"
+          src="/assets/logo/chonkie_logo_br_transparent_bg.png"
           alt="Chonkie"
           width={28}
           height={28}
-          className="rounded-sm"
+          className="rounded-sm h-7 w-auto object-contain"
         />
         <span>Chonkie</span>
       </>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated Visualizer docs to use site-relative `/assets/viz/` paths for terminal and HTML example screenshots.
  - Switched documentation site branding/icon images to local assets for the navigation logo and app/product switcher.
- **Chores**
  - Broadened repository and docs ignore rules for SQLite-related artifacts and environment/hosting files (`.env*`, `.vercel`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->