### PR TITLE
Fix OverlapRefinery crash when a float context_size rounds to zero tokens

### DIFF
--- a/src/chonkie/refinery/overlap.py
+++ b/src/chonkie/refinery/overlap.py
@@ -267,6 +267,13 @@ class OverlapRefinery(BaseRefinery):
             effective_context_size: The effective context size to use.
 
         """
+        # A float context_size can round down to zero tokens for a small chunk,
+        # which means no overlap. Return early: the recursive path would otherwise
+        # split with a zero step (range(..., 0)) and the token path would treat
+        # tokens[-0:] as the whole chunk.
+        if effective_context_size <= 0:
+            return ""
+
         # Route to the appropriate method
         if self.mode == "token":
             return self._prefix_overlap_token(chunk, effective_context_size)
@@ -364,6 +371,12 @@ class OverlapRefinery(BaseRefinery):
             effective_context_size: The effective context size to use.
 
         """
+        # A float context_size can round down to zero tokens for a small chunk,
+        # which means no overlap. Return early: the recursive path would otherwise
+        # split with a zero step (range(..., 0)).
+        if effective_context_size <= 0:
+            return ""
+
         # Route to the appropriate method
         if self.mode == "token":
             return self._suffix_overlap_token(chunk, effective_context_size)

--- a/tests/refinery/test_overlap_refinery.py
+++ b/tests/refinery/test_overlap_refinery.py
@@ -1003,3 +1003,56 @@ def test_overlap_refinery_justified_inplace_false() -> None:
     assert refined_chunks[0].context != ""
     assert refined_chunks[1].context != ""
     assert refined_chunks[2].context != ""
+
+
+def test_overlap_refinery_float_context_rounds_to_zero_recursive_suffix() -> None:
+    """A float context_size that rounds down to zero tokens must not crash.
+
+    int(0.25 * token_count) == 0 for a chunk of <= 3 tokens. The recursive path
+    previously split with a zero step (range(..., 0)) and raised
+    ValueError: range() arg 3 must not be zero. The correct result is no overlap.
+    """
+    chunks = [
+        Chunk(text="hi there", start_index=0, end_index=8, token_count=2),
+        Chunk(text="bye now", start_index=8, end_index=15, token_count=2),
+    ]
+    refinery = OverlapRefinery(context_size=0.25, mode="recursive", method="suffix", merge=True)
+    refined = refinery.refine(chunks)
+
+    assert len(refined) == 2
+    # No overlap fits, so the first chunk keeps its exact text and the context is empty.
+    assert refined[0].context == ""
+    assert refined[0].text == "hi there"
+
+
+def test_overlap_refinery_float_context_rounds_to_zero_recursive_prefix() -> None:
+    """The recursive prefix path must also degrade to no overlap, not crash."""
+    chunks = [
+        Chunk(text="hi there", start_index=0, end_index=8, token_count=2),
+        Chunk(text="bye now", start_index=8, end_index=15, token_count=2),
+    ]
+    refinery = OverlapRefinery(context_size=0.25, mode="recursive", method="prefix", merge=True)
+    refined = refinery.refine(chunks)
+
+    assert len(refined) == 2
+    assert refined[1].context == ""
+    assert refined[1].text == "bye now"
+
+
+def test_overlap_refinery_float_context_rounds_to_zero_token_prefix_no_duplication() -> None:
+    """Token prefix with a zero-rounded context must not duplicate the whole chunk.
+
+    tokens[-0:] equals tokens[:] (the entire chunk), so the previous chunk was
+    copied wholesale into the next chunk as "overlap". Zero tokens means no overlap.
+    """
+    chunks = [
+        Chunk(text="hi there", start_index=0, end_index=8, token_count=2),
+        Chunk(text="bye now", start_index=8, end_index=15, token_count=2),
+    ]
+    refinery = OverlapRefinery(context_size=0.25, mode="token", method="prefix", merge=True)
+    refined = refinery.refine(chunks)
+
+    assert len(refined) == 2
+    assert refined[1].context == ""
+    # The previous chunk's text must NOT be prepended.
+    assert refined[1].text == "bye now"


### PR DESCRIPTION
With a float `context_size` (the default is `0.25`), the per-chunk overlap is `int(context_size * prev_chunk.token_count)`. For a chunk of three or fewer tokens this rounds to `0`, and:

- `mode="recursive"` then splits with a zero step (`range(..., 0)`) and raises `ValueError: range() arg 3 must not be zero`;
- `mode="token", method="prefix"` uses `tokens[-0:]`, which is the whole chunk, so the entire previous chunk is copied in as overlap.

Zero tokens means no overlap, so the two overlap-context routers now return an empty context in that case. Reachable from `OverlapRefinery.refine()` with default settings whenever a chunk is small (a small `chunk_size`, or a short trailing chunk). Added three regression tests; the full overlap suite passes (52).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed overlap processing when the configured context size rounds down to zero.
  * Prevented crashes and unintended text duplication during recursive and token-based overlap handling.
  * Chunks now retain their original text with an empty context when no overlap can be applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->