### PR TITLE
docs(chunker): document None option for include_delim

### DIFF
--- a/src/chonkie/chunker/base.py
+++ b/src/chonkie/chunker/base.py
@@ -29,8 +29,8 @@ def split_text_by_delimiters(
     Args:
         text: Input text to be split.
         delimiters: Delimiter(s) to split on. Can be a single string or list of strings.
-        include_delim: Whether to include delimiters in the current chunk ("prev")
-            or the next chunk ("next").
+        include_delim: Whether to include delimiters in the current chunk ("prev"),
+            the next chunk ("next"), or to drop them entirely (None). Defaults to "prev".
         min_chars: Minimum number of characters per split.
 
     Returns:

--- a/src/chonkie/chunker/base.py
+++ b/src/chonkie/chunker/base.py
@@ -30,7 +30,8 @@ def split_text_by_delimiters(
         text: Input text to be split.
         delimiters: Delimiter(s) to split on. Can be a single string or list of strings.
         include_delim: Whether to include delimiters in the current chunk ("prev"),
-            the next chunk ("next"), or to drop them entirely (None). Defaults to "prev".
+            the next chunk ("next"), or to drop them entirely (None).
+            Defaults to "prev".
         min_chars: Minimum number of characters per split.
 
     Returns:


### PR DESCRIPTION
## What

`split_text_by_delimiters` in `src/chonkie/chunker/base.py` accepts `include_delim: Optional[str] = "prev"`, but its docstring only documented the "prev" and "next" options, omitting the valid `None` ("drop delimiters entirely") case.

The `None` option is a real, intended value: `sentence.py:86-87` enforces the contract `if include_delim not in ["prev", "next", None]: raise ValueError("include_delim must be 'prev', 'next' or None")`, and the sentence docstring describes it as the delimiters going in the "current chunk, next chunk or not at all".

## Fix

One-line docstring update to also document `None`:

```
include_delim: Whether to include delimiters in the current chunk ("prev"),
    the next chunk ("next"), or to drop them entirely (None). Defaults to "prev".
```

## Scope

Docs-only. No behavior change — a single docstring hunk in `base.py`.

## Verified

Cross-referenced the accepted-values contract in `sentence.py:86-87` (ValueError guard listing `None`) and the sibling docstring wording.