### PR TITLE
docs: fix stale Args in EmbeddingsRegistry.register_model docstring

### DIFF
--- a/src/chonkie/embeddings/registry.py
+++ b/src/chonkie/embeddings/registry.py
@@ -37,8 +37,6 @@ class EmbeddingsRegistry:
         Args:
             name: Unique identifier for this implementation
             embedding_cls: The embeddings class to register
-            pattern: Optional regex pattern string or compiled pattern
-            supported_types: Optional list of types that the embeddings class supports
 
         """
         if not issubclass(embedding_cls, BaseEmbeddings):


### PR DESCRIPTION
## What

`EmbeddingsRegistry.register_model()` accepts only `(name, embedding_cls)`, but its docstring documents two extra parameters that don't exist on the method:

```python
@classmethod
def register_model(cls, name: str, embedding_cls: type[BaseEmbeddings]) -> None:
    """Register a new embeddings implementation.

    Args:
        name: Unique identifier for this implementation
        embedding_cls: The embeddings class to register
        pattern: Optional regex pattern string or compiled pattern          # <- not a parameter
        supported_types: Optional list of types that the embeddings class supports  # <- not a parameter
    """
```

`pattern` and `supported_types` belong to the sibling classmethods `register_pattern()` and `register_types()`, which were split out into their own methods. The `register_model()` docstring was left describing the old combined signature.

This PR removes the two stale `Args` entries so the docstring matches the actual signature.

## Why

The docstring is the public API reference (and feeds the generated docs). Documenting non-existent `pattern` / `supported_types` arguments misleads users into passing kwargs that raise `TypeError`, and trips docstring/signature consistency checks.

## How verified

- `register_pattern()` / `register_types()` confirmed as the real homes of these parameters (same file).
- `ruff check src/chonkie/embeddings/registry.py` → `All checks passed!`
- Documentation-only change: no code behavior changes, no tests affected.

## Scope

Small and self-contained — a 2-line docstring correction in a single file. No behavior change.
