### PR TITLE
Fix FastChunker UnicodeDecodeError on multi-byte character boundaries

### DIFF
--- a/src/chonkie/chunker/fast.py
+++ b/src/chonkie/chunker/fast.py
@@ -1,5 +1,6 @@
 """Fast chunker powered by chonkie-core."""
 
+from bisect import bisect_left
 from typing import Any, Dict, List, Optional, Sequence
 
 import chonkie_core
@@ -96,22 +97,37 @@ class FastChunker(BaseChunker):
         # Get chunk offsets from chonkie-core (these are byte offsets)
         offsets = chonkie_core.chunk_offsets(text_bytes, **kwargs)
 
-        # Convert to Chunk objects by slicing bytes and decoding
-        # Track character position to convert byte offsets to char offsets
+        # chonkie-core returns byte offsets, and a hard size cut can land inside a
+        # multi-byte UTF-8 character; slicing the raw bytes there raises
+        # UnicodeDecodeError. Pure-ASCII text has byte offsets == char offsets, so
+        # the common case needs no remapping.
+        if len(text_bytes) == len(text):
+            return [
+                Chunk(text=text[start:end], start_index=start, end_index=end, token_count=0)
+                for start, end in offsets
+                if end > start
+            ]
+
+        # Otherwise snap each byte offset up to a character boundary so a chunk
+        # never splits a multi-byte character, then slice the decoded text.
+        char_starts = [0]
+        for char in text:
+            char_starts.append(char_starts[-1] + len(char.encode("utf-8")))
+
         chunks = []
-        char_pos = 0
         for start, end in offsets:
-            chunk_text = text_bytes[start:end].decode("utf-8")
-            chunk_char_len = len(chunk_text)
+            char_start = bisect_left(char_starts, start)
+            char_end = bisect_left(char_starts, end)
+            if char_end <= char_start:
+                continue
             chunks.append(
                 Chunk(
-                    text=chunk_text,
-                    start_index=char_pos,
-                    end_index=char_pos + chunk_char_len,
+                    text=text[char_start:char_end],
+                    start_index=char_start,
+                    end_index=char_end,
                     token_count=0,
                 )
             )
-            char_pos += chunk_char_len
         return chunks
 
     def chunk_batch(self, texts: Sequence[str], show_progress: bool = True) -> List[List[Chunk]]:

--- a/src/chonkie/chunker/fast.py
+++ b/src/chonkie/chunker/fast.py
@@ -110,9 +110,8 @@ class FastChunker(BaseChunker):
 
         # Otherwise snap each byte offset up to a character boundary so a chunk
         # never splits a multi-byte character, then slice the decoded text.
-        char_starts = [0]
-        for char in text:
-            char_starts.append(char_starts[-1] + len(char.encode("utf-8")))
+        char_starts = [i for i, b in enumerate(text_bytes) if (b & 0xC0) != 0x80]
+        char_starts.append(len(text_bytes))
 
         chunks = []
         for start, end in offsets:

--- a/tests/chunkers/test_fast_chunker.py
+++ b/tests/chunkers/test_fast_chunker.py
@@ -295,6 +295,29 @@ def test_fast_chunker_unicode_text() -> None:
     assert reconstructed == text
 
 
+def test_fast_chunker_multibyte_split_boundary() -> None:
+    """Test that a size cut inside a multi-byte UTF-8 char does not raise.
+
+    chonkie-core returns byte offsets, and a hard size cut can fall inside a
+    multi-byte character. Slicing the raw bytes there used to raise
+    UnicodeDecodeError; offsets are now snapped to character boundaries.
+    """
+    # chunk_size=2 forces cuts inside every 2-byte "é"; no delimiter is present.
+    text = "café café café café "
+    chunker = get_fast_chunker(chunk_size=2)
+    chunks = chunker.chunk(text)
+
+    assert len(chunks) > 0
+    reconstructed = "".join(chunk.text for chunk in chunks)
+    assert reconstructed == text
+    assert all(chunk.text == text[chunk.start_index : chunk.end_index] for chunk in chunks)
+
+    # A run of 3-byte CJK characters longer than a realistic chunk_size.
+    cjk = "这是一段没有分隔符的中文文本" * 20
+    cjk_chunks = get_fast_chunker(chunk_size=64).chunk(cjk)
+    assert "".join(chunk.text for chunk in cjk_chunks) == cjk
+
+
 def test_fast_chunker_no_tokenizer_attribute() -> None:
     """Test that FastChunker has _tokenizer set to None."""
     chunker = get_fast_chunker()


### PR DESCRIPTION
FastChunker.chunk() raises a raw UnicodeDecodeError on ordinary non-ASCII text whenever a chunk boundary falls inside a multi-byte UTF-8 character. chonkie-core returns byte offsets; when no delimiter fits the size budget it hard-cuts at a byte offset that can split a multi-byte char, and `text_bytes[start:end].decode("utf-8")` then crashes. The other chunkers do not crash on the same text.

Fix: snap each core byte offset to the nearest character boundary (bisect over precomputed char-start offsets) and slice the decoded `text` string by char index, skipping empty ranges. Every character is preserved (roundtrip join equals the input), no character is split across chunks, and pure-ASCII input takes a fast path that is byte-for-byte identical to the previous behaviour.

Repro:
```python
from chonkie import FastChunker
FastChunker(chunk_size=64).chunk('食べ物' * 50)   # UnicodeDecodeError: 'utf-8' can't decode byte ...
```

Added test_fast_chunker_multibyte_split_boundary; the existing unicode test used chunk_size=30, too large to land a cut mid-character.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed multilingual text chunking when boundary cuts land inside multi-byte UTF-8 characters, preventing decode errors.
  * Ensured each chunk’s text and indices remain accurate and match the original content.

* **Tests**
  * Added unit coverage for accented and CJK cases to confirm correct reconstruction and that chunk text exactly matches the reported substring ranges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->