### PR TITLE
fix: return empty JSON for markdown tables with blank headers

### DIFF
--- a/src/chonkie/utils/table_converter.py
+++ b/src/chonkie/utils/table_converter.py
@@ -14,8 +14,8 @@ def _read_markdown_table(table_content: str):
         ) from e
 
     lines = [line.strip("|").strip() for line in table_content.split("\n") if line.strip()]
-    # Empty header cells yield EmptyDataError from pandas read_csv.
-    if len(lines) < 2 or not lines[0]:
+    # Empty/blank headers (incl. multi-col "| | | |") yield EmptyDataError from pandas.
+    if len(lines) < 2 or not lines[0].replace("|", "").strip():
         return pd.DataFrame()
 
     csv_content = "\n".join([lines[0]] + lines[2:])

--- a/src/chonkie/utils/table_converter.py
+++ b/src/chonkie/utils/table_converter.py
@@ -14,7 +14,8 @@ def _read_markdown_table(table_content: str):
         ) from e
 
     lines = [line.strip("|").strip() for line in table_content.split("\n") if line.strip()]
-    if len(lines) < 2:
+    # Empty header cells yield EmptyDataError from pandas read_csv.
+    if len(lines) < 2 or not lines[0]:
         return pd.DataFrame()
 
     csv_content = "\n".join([lines[0]] + lines[2:])

--- a/tests/test_table_converter.py
+++ b/tests/test_table_converter.py
@@ -71,6 +71,9 @@ class TestMarkdownTableToJson:
         # Empty header cells must not leak pandas EmptyDataError.
         assert markdown_table_to_json("|\n|-|") == []
         assert markdown_table_to_json("||\n|-|") == []
+        # strip("|") leaves inner pipes for 3+ blank columns; still empty JSON.
+        assert markdown_table_to_json("| | | |\n|---|---|---|") == []
+        assert markdown_table_to_json("|  |  |  |  |\n|---|---|---|---|") == []
 
 
 class TestHTMLTableToJson:

--- a/tests/test_table_converter.py
+++ b/tests/test_table_converter.py
@@ -68,6 +68,9 @@ class TestMarkdownTableToJson:
         """Test empty and header-only tables."""
         assert markdown_table_to_json("") == []
         assert markdown_table_to_json("| Name |\n|------|") == []
+        # Empty header cells must not leak pandas EmptyDataError.
+        assert markdown_table_to_json("|\n|-|") == []
+        assert markdown_table_to_json("||\n|-|") == []
 
 
 class TestHTMLTableToJson:


### PR DESCRIPTION
markdown_table_to_json hits EmptyDataError when |\\n|-|. This PR fixes the regression with a focused test covering the case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Markdown tables when the header row contains no meaningful text.
  * Converting header-only or effectively empty/malformed Markdown tables to JSON now returns an empty list (with no errors).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->